### PR TITLE
feat: add text alignment setting

### DIFF
--- a/lib/app/models.dart
+++ b/lib/app/models.dart
@@ -218,3 +218,10 @@ enum AppTheme {
   amoled, // أسود — white on pure black
   sepia, // سيبيا — brown on beige
 }
+
+enum TextAlignOption {
+  justify, // ضبط
+  center, // توسيط
+  start, // محاذاة لليمين
+  auto, // تلقائي (smart rules)
+}

--- a/lib/app/pages/home_page.dart
+++ b/lib/app/pages/home_page.dart
@@ -878,10 +878,31 @@ class _SurahTextBlockState extends State<_SurahTextBlock> {
   }
 
   TextAlign _calculateAlignment() {
-    if (Quran.instance.getVerseCount(widget.surahNumber) <= 20) {
-      return TextAlign.center;
+    return switch (widget.settingsController.textAlign) {
+      TextAlignOption.center => TextAlign.center,
+      TextAlignOption.start => TextAlign.start,
+      TextAlignOption.justify => TextAlign.justify,
+      TextAlignOption.auto => _autoAlignment(),
+    };
+  }
+
+  TextAlign _autoAlignment() {
+    final verseCount = Quran.instance.getVerseCount(widget.surahNumber);
+
+    // Short surahs: center
+    if (verseCount <= 20) return TextAlign.center;
+
+    // Large font: center (few words per line)
+    if (widget.fontSize > 34) return TextAlign.center;
+
+    // Few words in block: center (avoids ugly justify gaps)
+    int totalWords = 0;
+    for (final seg in widget.block.segments) {
+      totalWords += seg.text.split(' ').length;
     }
-    return widget.fontSize > 34 ? TextAlign.center : TextAlign.justify;
+    if (totalWords < 15) return TextAlign.center;
+
+    return TextAlign.justify;
   }
 
   @override

--- a/lib/app/services/settings_service.dart
+++ b/lib/app/services/settings_service.dart
@@ -90,4 +90,18 @@ class SettingsService {
   Future<void> setAppTheme(AppTheme theme) async {
     await _prefs.setString(_appThemeKey, theme.name);
   }
+
+  static const String _textAlignKey = 'text_align';
+
+  Future<TextAlignOption> loadTextAlign() async {
+    final value = await _prefs.getString(_textAlignKey);
+    return TextAlignOption.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => TextAlignOption.auto,
+    );
+  }
+
+  Future<void> setTextAlign(TextAlignOption align) async {
+    await _prefs.setString(_textAlignKey, align.name);
+  }
 }

--- a/lib/app/settings_controller.dart
+++ b/lib/app/settings_controller.dart
@@ -19,6 +19,7 @@ class SettingsController extends ChangeNotifier {
   AppTheme _appTheme = AppTheme.light;
   bool _isHorizontalScrolling = false;
   bool _keepScreenOn = true;
+  TextAlignOption _textAlign = TextAlignOption.auto;
 
   // ── Getters ──
 
@@ -29,6 +30,7 @@ class SettingsController extends ChangeNotifier {
   String get language => _language;
   FontFamily get fontFamily => _fontFamily;
   FontWeight get fontWeight => _fontWeight;
+  TextAlignOption get textAlign => _textAlign;
 
   // Backward compat: some code checks this
   bool get useTrueBlackBgColor => _appTheme == AppTheme.amoled;
@@ -68,6 +70,11 @@ class SettingsController extends ChangeNotifier {
     settingsService.setFontWeight(value);
   }
 
+  set textAlign(TextAlignOption value) {
+    _textAlign = value;
+    notifyListeners();
+    settingsService.setTextAlign(value);
+  }
   // ── Actions ──
 
   /// Quick toggle: light↔dark. Returns false if theme needs picker.
@@ -102,6 +109,8 @@ class SettingsController extends ChangeNotifier {
     _fontWeight = await settingsService.loadFontWeight();
     _isHorizontalScrolling = await settingsService.loadIsHorizontalScroling();
     _keepScreenOn = await settingsService.loadKeepScreenOn();
+    _textAlign = await settingsService.loadTextAlign();
+
     unawaited(_applyWakelock());
 
     debugPrint('✅ Loaded settings');

--- a/lib/app/widgets/settings_sheet.dart
+++ b/lib/app/widgets/settings_sheet.dart
@@ -83,6 +83,38 @@ class SettingsSheet extends StatelessWidget {
                 onChanged: (theme) => settingsController.appTheme = theme,
               ),
               const SizedBox(height: 16),
+
+              // ── TEXT ALIGNMENT ──
+              _buildSectionTitle('محاذاة النص'),
+              SizedBox(
+                width: double.infinity,
+                child: SegmentedButton<TextAlignOption>(
+                  segments: const [
+                    ButtonSegment(
+                      value: TextAlignOption.auto,
+                      label: Text('تلقائي'),
+                    ),
+                    ButtonSegment(
+                      value: TextAlignOption.justify,
+                      label: Text('ضبط'),
+                    ),
+                    ButtonSegment(
+                      value: TextAlignOption.center,
+                      label: Text('وسط'),
+                    ),
+                    ButtonSegment(
+                      value: TextAlignOption.start,
+                      label: Text('يمين'),
+                    ),
+                  ],
+                  style: segmentStyle,
+                  selected: {settingsController.textAlign},
+                  onSelectionChanged: (newSet) {
+                    settingsController.textAlign = newSet.first;
+                  },
+                ),
+              ),
+              const SizedBox(height: 24),
               const Divider(),
               const SizedBox(height: 16),
 


### PR DESCRIPTION
Add TextAlignOption (auto/justify/center/right) to settings. Auto mode preserves existing smart rules: centers short surahs, large fonts, and blocks with few words, justifies otherwise. User can override to always justify, center, or right-align.

close #34 

## Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.
