### PR TITLE
fix: search result incorrect highlighting 

### DIFF
--- a/lib/app/widgets/search_sheet.dart
+++ b/lib/app/widgets/search_sheet.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:my_quran/app/models.dart';
@@ -50,7 +51,7 @@ class _QuranSearchBottomSheetState extends State<QuranSearchBottomSheet> {
     setState(() => _isSearching = true);
 
     final rawTokens = ArabicTextProcessor.tokenize(query);
-    _currentQueryTokens = rawTokens.map(ArabicTextProcessor.normalize).toSet();
+    _currentQueryTokens = rawTokens.toSet();
 
     // Pass the toggle value to the service
     final results = SearchService.search(query, exactMatch: _isExactMatch);
@@ -267,6 +268,7 @@ class SearchResultItem extends StatelessWidget {
 
             // --- Body: Highlighted Verse Text ---
             _HighlightedText(
+              debug: true,
               plainText: Quran.instance.getVerseInPlainText(
                 result.surah,
                 result.verse,
@@ -296,6 +298,7 @@ class _HighlightedText extends StatelessWidget {
     required this.baseColor,
     required this.queryTokens,
     required this.highlightExactMatchOnly,
+    this.debug = false,
   });
 
   final String plainText;
@@ -307,52 +310,230 @@ class _HighlightedText extends StatelessWidget {
   final bool highlightExactMatchOnly;
   final FontFamily verseFontFamily;
 
+  /// Enable to print mapping / matching diagnostics.
+  final bool debug;
+
+  // ---------------- Debug helpers ----------------
+  void _d(String msg) {
+    if (kDebugMode && debug) debugPrint(msg);
+  }
+
+  String _codepoints(String s) => s.runes
+      .map((r) => 'U+${r.toRadixString(16).toUpperCase().padLeft(4, '0')}')
+      .join(' ');
+
+  String _visible(String s) => s
+      .replaceAll('\u00A0', '[NBSP]')
+      .replaceAll('\u200F', '[RLM]')
+      .replaceAll('\u200E', '[LRM]')
+      .replaceAll('\u202A', '[LRE]')
+      .replaceAll('\u202B', '[RLE]')
+      .replaceAll('\u202C', '[PDF]')
+      .replaceAll('\u202D', '[LRO]')
+      .replaceAll('\u202E', '[RLO]')
+      .replaceAll('\u2066', '[LRI]')
+      .replaceAll('\u2067', '[RLI]')
+      .replaceAll('\u2068', '[FSI]')
+      .replaceAll('\u2069', '[PDI]');
+
+  // ---------------- Tokenization / classification ----------------
+  List<String> _splitWords(String s) =>
+      s.trim().split(RegExp(r'\s+')).where((e) => e.isNotEmpty).toList();
+
+  String _stripBidi(String s) =>
+      s.replaceAll(RegExp(r'[\u200E\u200F\u202A-\u202E\u2066-\u2069]'), '');
+
+  bool _containsPua(String s) => s.runes.any((r) => r >= 0xE000 && r <= 0xF8FF);
+
+  String _stripQuranMarksAndHarakat(String s) {
+    return s
+        .replaceAll('\u0670', 'ا')
+        // harakat (WITHOUT \u0670)
+        .replaceAll(RegExp(r'[\u064B-\u065F]'), '')
+        // Quran annotation marks (ۖ ۚ ۗ ۞ etc.)
+        .replaceAll(RegExp(r'[\u06D6-\u06ED\u08D3-\u08FF]'), '')
+        // end of ayah (if present)
+        .replaceAll('\u06DD', '');
+  }
+
+  bool _hasArabicLetter(String s) {
+    // Includes alef wasla (ٱ U+0671) + basic Arabic letters.
+    return RegExp(r'[\u0621-\u064A\u0671]').hasMatch(s);
+  }
+
+  bool _isPlainWordToken(String token) {
+    // A "real word" is any token that contains Arabic letters after removing marks.
+    final t = _stripQuranMarksAndHarakat(token);
+    return _hasArabicLetter(t);
+  }
+
+  bool _isDisplayWordToken(String token) {
+    // Display text may be PUA glyph stream; treat PUA sequences as words.
+    final t = _stripBidi(token).trim();
+    if (t.isEmpty) return false;
+    if (_containsPua(t)) return true;
+
+    // Also support normal-unicode Arabic display.
+    final stripped = _stripQuranMarksAndHarakat(t);
+    return _hasArabicLetter(stripped);
+  }
+
+  // ---------------- Matching normalization ----------------
+  String _normalizeForMatch(String s) {
+    // 1) remove Quran marks/harakat that might appear in plain
+    s = _stripQuranMarksAndHarakat(s);
+
+    // 2) normalize your Arabic (alef forms etc.)
+    s = ArabicTextProcessor.normalize(s);
+
+    // 3) remove punctuation/non-letters around/inside token for matching
+    s = s.replaceAll(RegExp(r'[^\u0600-\u06FF0-9]+'), '');
+
+    // 4) make search equivalence match highlight equivalence:
+    //    taa marbuta vs haa (then "ثمرة" highlights "ثمره")
+    s = s.replaceAll(RegExp(r'ة$'), 'ه');
+
+    return s;
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    final List<String> words = plainText.trim().split(RegExp(r'\s+'));
+    // ---- 1) Split tokens ----
+    final plainTokens = _splitWords(plainText);
 
-    // 1. Find the index of the first match
-    int firstMatchIndex = -1;
+    // IMPORTANT: keep original display tokens (don’t strip bidi globally),
+    // but drop tokens that are only bidi markers.
+    final displayTokens = _splitWords(
+      displayText,
+    ).where((t) => _stripBidi(t).trim().isNotEmpty).toList();
 
-    for (int i = 0; i < words.length; i++) {
-      final cleanWord = ArabicTextProcessor.normalize(words[i]);
-      bool isMatch = false;
-
-      if (highlightExactMatchOnly) {
-        isMatch = queryTokens.contains(cleanWord);
+    // ---- 2) Filter plain to content-words only (skip ۞ ۖ ۚ ۗ etc) ----
+    final plainContentWords = <String>[];
+    for (int i = 0; i < plainTokens.length; i++) {
+      final t = plainTokens[i];
+      final isWord = _isPlainWordToken(t);
+      if (!isWord) {
+        _d('PLAIN SKIP i=$i "${_visible(t)}" cps=${_codepoints(t)}');
       } else {
-        for (final q in queryTokens) {
-          if (cleanWord.startsWith(q)) {
-            isMatch = true;
-            break;
-          }
-        }
+        plainContentWords.add(t);
+      }
+    }
+
+    // ---- 3) Normalize query tokens the SAME way highlight does ----
+    // (Union: use passed queryTokens + split(query) as a fallback)
+    final rawQueryTokens = <String>{...queryTokens, ..._splitWords(query)};
+
+    final normalizedQueryTokens = rawQueryTokens
+        .map(_normalizeForMatch)
+        .where((t) => t.isNotEmpty)
+        .toSet();
+
+    bool matches(String normalizedPlainWord) {
+      if (normalizedPlainWord.isEmpty || normalizedQueryTokens.isEmpty) {
+        return false;
       }
 
-      if (isMatch) {
-        firstMatchIndex = i;
+      if (highlightExactMatchOnly) {
+        return normalizedQueryTokens.contains(normalizedPlainWord);
+      } else {
+        for (final q in normalizedQueryTokens) {
+          if (normalizedPlainWord.startsWith(q)) return true;
+        }
+        return false;
+      }
+    }
+
+    _d('QUERY normalized tokens = $normalizedQueryTokens');
+
+    // ---- 4) Build display->plain mapping (consume only display "word tokens") ----
+    final displayToPlain = <int?>[];
+    int p = 0;
+    int displayWordCount = 0;
+
+    for (int d = 0; d < displayTokens.length; d++) {
+      final dt = displayTokens[d];
+      final isWord = _isDisplayWordToken(dt);
+
+      if (isWord) {
+        displayWordCount++;
+        displayToPlain.add(p < plainContentWords.length ? p : null);
+        p++;
+      } else {
+        displayToPlain.add(null);
+      }
+    }
+
+    _d(
+      'COUNTS: plainTokens=${plainTokens.length}, '
+      'plainContentWords=${plainContentWords.length}, '
+      'displayTokens=${displayTokens.length}, '
+      'displayWordCount=$displayWordCount',
+    );
+
+    if (displayWordCount != plainContentWords.length) {
+      _d(
+        'WARNING: word-count mismatch -> alignment may drift.\n'
+        '  displayWordCount=$displayWordCount vs plainContentWords=${plainContentWords.length}',
+      );
+    }
+
+    // ---- 5) Find first match in PLAIN content words ----
+    int firstMatchPlainIndex = -1;
+    for (int i = 0; i < plainContentWords.length; i++) {
+      final norm = _normalizeForMatch(plainContentWords[i]);
+      if (matches(norm)) {
+        firstMatchPlainIndex = i;
         break;
       }
     }
 
-    // 2. Calculate Start Index for display
-    int startIndex = 0;
+    // Convert to DISPLAY index
+    int firstMatchDisplayIndex = -1;
+    if (firstMatchPlainIndex != -1) {
+      firstMatchDisplayIndex = displayToPlain.indexWhere(
+        (m) => m == firstMatchPlainIndex,
+      );
+    }
+
+    _d(
+      'MATCH: firstMatchPlainIndex=$firstMatchPlainIndex '
+      '-> firstMatchDisplayIndex=$firstMatchDisplayIndex',
+    );
+
+    if (firstMatchPlainIndex == -1) {
+      // Very useful when you see results but no highlight:
+      // it means your normalization still differs from search.
+      _d(
+        'NO MATCH FOUND. Sample normalized plain words (first 25): '
+        '${plainContentWords.take(25).map(_normalizeForMatch).toList()}',
+      );
+    }
+
+    // ---- 6) Decide slicing based on DISPLAY indices (since we render display) ----
+    int startDisplayIndex = 0;
     bool showStartEllipsis = false;
 
-    if (firstMatchIndex > 10) {
-      startIndex = firstMatchIndex - 3;
+    if (firstMatchDisplayIndex > 10) {
+      startDisplayIndex = firstMatchDisplayIndex - 3;
       showStartEllipsis = true;
     }
-    // 3. Slice the list
 
-    final displayWords = displayText.split(RegExp(r'\s+')).sublist(startIndex);
+    final slicedDisplayTokens = displayTokens.sublist(startDisplayIndex);
+    final slicedMap = displayToPlain.sublist(startDisplayIndex);
+
+    // Keep old behavior but safer: only trim trailing non-word display tokens.
     if (verseFontFamily == FontFamily.hafs) {
-      displayWords.removeLast();
+      while (slicedDisplayTokens.isNotEmpty &&
+          !_isDisplayWordToken(slicedDisplayTokens.last)) {
+        slicedDisplayTokens.removeLast();
+        slicedMap.removeLast();
+      }
     }
 
     final isWarsh = verseFontFamily == FontFamily.warsh;
+
     return RichText(
       textDirection: TextDirection.rtl,
       maxLines: 2,
@@ -370,30 +551,23 @@ class _HighlightedText extends StatelessWidget {
           if (showStartEllipsis)
             TextSpan(
               text: '... ',
-              style: TextStyle(color: baseColor.applyOpacity(0.8)),
+              style: TextStyle(color: baseColor.withOpacity(0.8)),
             ),
-          ...List.generate(displayWords.length, (index) {
-            final word = displayWords[index];
-            final cleanWord = ArabicTextProcessor.normalize(words[index]);
+          ...List.generate(slicedDisplayTokens.length, (i) {
+            final displayTok = slicedDisplayTokens[i];
+            final plainIndex = slicedMap[i];
 
             bool isMatch = false;
-
-            if (highlightExactMatchOnly) {
-              isMatch = queryTokens.contains(cleanWord);
-            } else {
-              for (final q in queryTokens) {
-                if (cleanWord.startsWith(q)) {
-                  isMatch = true;
-                  break;
-                }
-              }
+            if (plainIndex != null && plainIndex < plainContentWords.length) {
+              final norm = _normalizeForMatch(plainContentWords[plainIndex]);
+              isMatch = matches(norm);
             }
 
             return TextSpan(
-              text: '$word ',
+              text: '$displayTok ',
               style: isMatch
                   ? TextStyle(
-                      backgroundColor: colorScheme.primary,
+                      backgroundColor: highlightColor,
                       color: colorScheme.onPrimary,
                     )
                   : null,

--- a/lib/app/widgets/settings_sheet.dart
+++ b/lib/app/widgets/settings_sheet.dart
@@ -263,7 +263,8 @@ class SettingsSheet extends StatelessWidget {
                       icon: Icons.numbers_outlined,
                       title: 'عرض رقم الحزب',
                       subtitle:
-                          'يظهر رقم الحزب بدلاً من رقم الجزء في الشريط المُثبت.',
+                          'يظهر رقم الحزب بدلاً من '
+                          'رقم الجزء في الشريط المُثبت.',
                       value: !settingsController.hizbDisplay.isHidden,
                       onChanged: (displayed) =>
                           settingsController.hizbDisplay = displayed


### PR DESCRIPTION

The highlight logic previously assumed plainText and displayText split into the same word list and could be indexed interchangeably. This breaks for Quran text because:
- plainText can contain standalone Quran marks (ۖ ۚ ۗ ۞ etc.) that become extra whitespace tokens
- displayText can be a PUA-glyph stream (U+E000..U+F8FF) with bidi markers (RLM) that do not normalize to Arabic letters
- slicing displayWords without applying the same offset to plainWords caused off-by-startIndex highlighting

Fix by:
- building plainContentWords by filtering out non-word Quran marks tokens
- classifying display tokens as “word” vs “non-word” (PUA tokens count as words)
- constructing an explicit displayToken -> plainContentWord index mapping to prevent drift
- keeping original display tokens for rendering (preserves RTL ordering via RLM), while ignoring bidi-only tokens for mapping
- unifying query/word match normalization, including:
  - dagger alif (U+0670) -> Alef (ا) before stripping harakat (so خالدون matches)
- adding debug prints for token skips, counts, and match indices

## Related

close #42 

## Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.
