### PR TITLE
refactor: optimize page lookups, fix verse count bug, and add Warsh pageData

### DIFF
--- a/lib/app/pages/home_page.dart
+++ b/lib/app/pages/home_page.dart
@@ -68,7 +68,7 @@ class HomePageState extends State<HomePage> with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
 
     _highlightedVerseNotifier = ValueNotifier(null);
-    Quran.data.addListener(_onQuranDataChanged);
+    Quran.instance.data.addListener(_onQuranDataChanged);
     _currentPositionNotifier = ValueNotifier(
       widget.initialPosition ??
           const ReadingPosition(
@@ -295,7 +295,7 @@ class HomePageState extends State<HomePage> with WidgetsBindingObserver {
     _itemPositionsListener.itemPositions.removeListener(_onScrollUpdate);
     WidgetsBinding.instance.removeObserver(this);
     _currentPositionNotifier.dispose();
-    Quran.data.removeListener(_onQuranDataChanged);
+    Quran.instance.data.removeListener(_onQuranDataChanged);
     widget.settingsController.removeListener(_onScrollingModeChanged);
     _fontSizeController.dispose();
     super.dispose();

--- a/lib/app/widgets/search_sheet.dart
+++ b/lib/app/widgets/search_sheet.dart
@@ -381,19 +381,15 @@ class _HighlightedText extends StatelessWidget {
   // ---------------- Matching normalization ----------------
   String _normalizeForMatch(String s) {
     // 1) remove Quran marks/harakat that might appear in plain
-    s = _stripQuranMarksAndHarakat(s);
+    final stripped = _stripQuranMarksAndHarakat(s);
 
     // 2) normalize your Arabic (alef forms etc.)
-    s = ArabicTextProcessor.normalize(s);
-
-    // 3) remove punctuation/non-letters around/inside token for matching
-    s = s.replaceAll(RegExp(r'[^\u0600-\u06FF0-9]+'), '');
-
-    // 4) make search equivalence match highlight equivalence:
-    //    taa marbuta vs haa (then "ثمرة" highlights "ثمره")
-    s = s.replaceAll(RegExp(r'ة$'), 'ه');
-
-    return s;
+    return ArabicTextProcessor.normalize(stripped)
+      // 3) remove punctuation/non-letters around/inside token for matching
+      ..replaceAll(RegExp(r'[^\u0600-\u06FF0-9]+'), '')
+      // 4) make search equivalence match highlight equivalence:
+      //    taa marbuta vs haa (then "ثمرة" highlights "ثمره")
+      ..replaceAll(RegExp(r'ة$'), 'ه');
   }
 
   @override
@@ -447,7 +443,7 @@ class _HighlightedText extends StatelessWidget {
 
     _d('QUERY normalized tokens = $normalizedQueryTokens');
 
-    // ---- 4) Build display->plain mapping (consume only display "word tokens") ----
+    // ---- 4) Build display->plain mapping (consume only display "word tokens")
     final displayToPlain = <int?>[];
     int p = 0;
     int displayWordCount = 0;
@@ -475,7 +471,8 @@ class _HighlightedText extends StatelessWidget {
     if (displayWordCount != plainContentWords.length) {
       _d(
         'WARNING: word-count mismatch -> alignment may drift.\n'
-        '  displayWordCount=$displayWordCount vs plainContentWords=${plainContentWords.length}',
+        '  displayWordCount=$displayWordCount vs'
+        ' plainContentWords=${plainContentWords.length}',
       );
     }
 

--- a/lib/app/widgets/settings_sheet.dart
+++ b/lib/app/widgets/settings_sheet.dart
@@ -134,7 +134,7 @@ class SettingsSheet extends StatelessWidget {
                             const Duration(milliseconds: 300),
                           );
                           final newFont = settingsController.fontFamily;
-                          await Quran.useDatasourceForFont(newFont);
+                          await Quran.instance.useDatasourceForFont(newFont);
                           unawaited(SearchService.init(newFont.name));
                         },
                       ),
@@ -171,7 +171,9 @@ class SettingsSheet extends StatelessWidget {
                             await Future<void>.delayed(
                               const Duration(milliseconds: 300),
                             );
-                            await Quran.useDatasourceForFont(newSet.first);
+                            await Quran.instance.useDatasourceForFont(
+                              newSet.first,
+                            );
                           },
                         ),
                       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,7 +26,7 @@ Future<void> main() async {
 
   unawaited(SearchService.init(settingsController.fontFamily.name));
 
-  await Quran.initialize(fontFamily: settingsController.fontFamily);
+  await Quran.instance.initialize(fontFamily: settingsController.fontFamily);
   await FontSizeController().initialize();
 
   final lastPosition = await ReadingPositionService.loadPosition();

--- a/lib/quran/data/hafs_page_data.dart
+++ b/lib/quran/data/hafs_page_data.dart
@@ -1,0 +1,1872 @@
+const List<List<Map<String, int>>> hafsPageData = [
+  [
+    {'surah': 1, 'start': 1, 'end': 7},
+  ],
+  [
+    {'surah': 2, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 2, 'start': 6, 'end': 16},
+  ],
+  [
+    {'surah': 2, 'start': 17, 'end': 24},
+  ],
+  [
+    {'surah': 2, 'start': 25, 'end': 29},
+  ],
+  [
+    {'surah': 2, 'start': 30, 'end': 37},
+  ],
+  [
+    {'surah': 2, 'start': 38, 'end': 48},
+  ],
+  [
+    {'surah': 2, 'start': 49, 'end': 57},
+  ],
+  [
+    {'surah': 2, 'start': 58, 'end': 61},
+  ],
+  [
+    {'surah': 2, 'start': 62, 'end': 69},
+  ],
+  [
+    {'surah': 2, 'start': 70, 'end': 76},
+  ],
+  [
+    {'surah': 2, 'start': 77, 'end': 83},
+  ],
+  [
+    {'surah': 2, 'start': 84, 'end': 88},
+  ],
+  [
+    {'surah': 2, 'start': 89, 'end': 93},
+  ],
+  [
+    {'surah': 2, 'start': 94, 'end': 101},
+  ],
+  [
+    {'surah': 2, 'start': 102, 'end': 105},
+  ],
+  [
+    {'surah': 2, 'start': 106, 'end': 112},
+  ],
+  [
+    {'surah': 2, 'start': 113, 'end': 119},
+  ],
+  [
+    {'surah': 2, 'start': 120, 'end': 126},
+  ],
+  [
+    {'surah': 2, 'start': 127, 'end': 134},
+  ],
+  [
+    {'surah': 2, 'start': 135, 'end': 141},
+  ],
+  [
+    {'surah': 2, 'start': 142, 'end': 145},
+  ],
+  [
+    {'surah': 2, 'start': 146, 'end': 153},
+  ],
+  [
+    {'surah': 2, 'start': 154, 'end': 163},
+  ],
+  [
+    {'surah': 2, 'start': 164, 'end': 169},
+  ],
+  [
+    {'surah': 2, 'start': 170, 'end': 176},
+  ],
+  [
+    {'surah': 2, 'start': 177, 'end': 181},
+  ],
+  [
+    {'surah': 2, 'start': 182, 'end': 186},
+  ],
+  [
+    {'surah': 2, 'start': 187, 'end': 190},
+  ],
+  [
+    {'surah': 2, 'start': 191, 'end': 196},
+  ],
+  [
+    {'surah': 2, 'start': 197, 'end': 202},
+  ],
+  [
+    {'surah': 2, 'start': 203, 'end': 210},
+  ],
+  [
+    {'surah': 2, 'start': 211, 'end': 215},
+  ],
+  [
+    {'surah': 2, 'start': 216, 'end': 219},
+  ],
+  [
+    {'surah': 2, 'start': 220, 'end': 224},
+  ],
+  [
+    {'surah': 2, 'start': 225, 'end': 230},
+  ],
+  [
+    {'surah': 2, 'start': 231, 'end': 233},
+  ],
+  [
+    {'surah': 2, 'start': 234, 'end': 237},
+  ],
+  [
+    {'surah': 2, 'start': 238, 'end': 245},
+  ],
+  [
+    {'surah': 2, 'start': 246, 'end': 248},
+  ],
+  [
+    {'surah': 2, 'start': 249, 'end': 252},
+  ],
+  [
+    {'surah': 2, 'start': 253, 'end': 256},
+  ],
+  [
+    {'surah': 2, 'start': 257, 'end': 259},
+  ],
+  [
+    {'surah': 2, 'start': 260, 'end': 264},
+  ],
+  [
+    {'surah': 2, 'start': 265, 'end': 269},
+  ],
+  [
+    {'surah': 2, 'start': 270, 'end': 274},
+  ],
+  [
+    {'surah': 2, 'start': 275, 'end': 281},
+  ],
+  [
+    {'surah': 2, 'start': 282, 'end': 282},
+  ],
+  [
+    {'surah': 2, 'start': 283, 'end': 286},
+  ],
+  [
+    {'surah': 3, 'start': 1, 'end': 9},
+  ],
+  [
+    {'surah': 3, 'start': 10, 'end': 15},
+  ],
+  [
+    {'surah': 3, 'start': 16, 'end': 22},
+  ],
+  [
+    {'surah': 3, 'start': 23, 'end': 29},
+  ],
+  [
+    {'surah': 3, 'start': 30, 'end': 37},
+  ],
+  [
+    {'surah': 3, 'start': 38, 'end': 45},
+  ],
+  [
+    {'surah': 3, 'start': 46, 'end': 52},
+  ],
+  [
+    {'surah': 3, 'start': 53, 'end': 61},
+  ],
+  [
+    {'surah': 3, 'start': 62, 'end': 70},
+  ],
+  [
+    {'surah': 3, 'start': 71, 'end': 77},
+  ],
+  [
+    {'surah': 3, 'start': 78, 'end': 83},
+  ],
+  [
+    {'surah': 3, 'start': 84, 'end': 91},
+  ],
+  [
+    {'surah': 3, 'start': 92, 'end': 100},
+  ],
+  [
+    {'surah': 3, 'start': 101, 'end': 108},
+  ],
+  [
+    {'surah': 3, 'start': 109, 'end': 115},
+  ],
+  [
+    {'surah': 3, 'start': 116, 'end': 121},
+  ],
+  [
+    {'surah': 3, 'start': 122, 'end': 132},
+  ],
+  [
+    {'surah': 3, 'start': 133, 'end': 140},
+  ],
+  [
+    {'surah': 3, 'start': 141, 'end': 148},
+  ],
+  [
+    {'surah': 3, 'start': 149, 'end': 153},
+  ],
+  [
+    {'surah': 3, 'start': 154, 'end': 157},
+  ],
+  [
+    {'surah': 3, 'start': 158, 'end': 165},
+  ],
+  [
+    {'surah': 3, 'start': 166, 'end': 173},
+  ],
+  [
+    {'surah': 3, 'start': 174, 'end': 180},
+  ],
+  [
+    {'surah': 3, 'start': 181, 'end': 186},
+  ],
+  [
+    {'surah': 3, 'start': 187, 'end': 194},
+  ],
+  [
+    {'surah': 3, 'start': 195, 'end': 200},
+  ],
+  [
+    {'surah': 4, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 4, 'start': 7, 'end': 11},
+  ],
+  [
+    {'surah': 4, 'start': 12, 'end': 14},
+  ],
+  [
+    {'surah': 4, 'start': 15, 'end': 19},
+  ],
+  [
+    {'surah': 4, 'start': 20, 'end': 23},
+  ],
+  [
+    {'surah': 4, 'start': 24, 'end': 26},
+  ],
+  [
+    {'surah': 4, 'start': 27, 'end': 33},
+  ],
+  [
+    {'surah': 4, 'start': 34, 'end': 37},
+  ],
+  [
+    {'surah': 4, 'start': 38, 'end': 44},
+  ],
+  [
+    {'surah': 4, 'start': 45, 'end': 51},
+  ],
+  [
+    {'surah': 4, 'start': 52, 'end': 59},
+  ],
+  [
+    {'surah': 4, 'start': 60, 'end': 65},
+  ],
+  [
+    {'surah': 4, 'start': 66, 'end': 74},
+  ],
+  [
+    {'surah': 4, 'start': 75, 'end': 79},
+  ],
+  [
+    {'surah': 4, 'start': 80, 'end': 86},
+  ],
+  [
+    {'surah': 4, 'start': 87, 'end': 91},
+  ],
+  [
+    {'surah': 4, 'start': 92, 'end': 94},
+  ],
+  [
+    {'surah': 4, 'start': 95, 'end': 101},
+  ],
+  [
+    {'surah': 4, 'start': 102, 'end': 105},
+  ],
+  [
+    {'surah': 4, 'start': 106, 'end': 113},
+  ],
+  [
+    {'surah': 4, 'start': 114, 'end': 121},
+  ],
+  [
+    {'surah': 4, 'start': 122, 'end': 127},
+  ],
+  [
+    {'surah': 4, 'start': 128, 'end': 134},
+  ],
+  [
+    {'surah': 4, 'start': 135, 'end': 140},
+  ],
+  [
+    {'surah': 4, 'start': 141, 'end': 147},
+  ],
+  [
+    {'surah': 4, 'start': 148, 'end': 154},
+  ],
+  [
+    {'surah': 4, 'start': 155, 'end': 162},
+  ],
+  [
+    {'surah': 4, 'start': 163, 'end': 170},
+  ],
+  [
+    {'surah': 4, 'start': 171, 'end': 175},
+  ],
+  [
+    {'surah': 4, 'start': 176, 'end': 176},
+    {'surah': 5, 'start': 1, 'end': 2},
+  ],
+  [
+    {'surah': 5, 'start': 3, 'end': 5},
+  ],
+  [
+    {'surah': 5, 'start': 6, 'end': 9},
+  ],
+  [
+    {'surah': 5, 'start': 10, 'end': 13},
+  ],
+  [
+    {'surah': 5, 'start': 14, 'end': 17},
+  ],
+  [
+    {'surah': 5, 'start': 18, 'end': 23},
+  ],
+  [
+    {'surah': 5, 'start': 24, 'end': 31},
+  ],
+  [
+    {'surah': 5, 'start': 32, 'end': 36},
+  ],
+  [
+    {'surah': 5, 'start': 37, 'end': 41},
+  ],
+  [
+    {'surah': 5, 'start': 42, 'end': 45},
+  ],
+  [
+    {'surah': 5, 'start': 46, 'end': 50},
+  ],
+  [
+    {'surah': 5, 'start': 51, 'end': 57},
+  ],
+  [
+    {'surah': 5, 'start': 58, 'end': 64},
+  ],
+  [
+    {'surah': 5, 'start': 65, 'end': 70},
+  ],
+  [
+    {'surah': 5, 'start': 71, 'end': 76},
+  ],
+  [
+    {'surah': 5, 'start': 77, 'end': 82},
+  ],
+  [
+    {'surah': 5, 'start': 83, 'end': 89},
+  ],
+  [
+    {'surah': 5, 'start': 90, 'end': 95},
+  ],
+  [
+    {'surah': 5, 'start': 96, 'end': 103},
+  ],
+  [
+    {'surah': 5, 'start': 104, 'end': 108},
+  ],
+  [
+    {'surah': 5, 'start': 109, 'end': 113},
+  ],
+  [
+    {'surah': 5, 'start': 114, 'end': 120},
+  ],
+  [
+    {'surah': 6, 'start': 1, 'end': 8},
+  ],
+  [
+    {'surah': 6, 'start': 9, 'end': 18},
+  ],
+  [
+    {'surah': 6, 'start': 19, 'end': 27},
+  ],
+  [
+    {'surah': 6, 'start': 28, 'end': 35},
+  ],
+  [
+    {'surah': 6, 'start': 36, 'end': 44},
+  ],
+  [
+    {'surah': 6, 'start': 45, 'end': 52},
+  ],
+  [
+    {'surah': 6, 'start': 53, 'end': 59},
+  ],
+  [
+    {'surah': 6, 'start': 60, 'end': 68},
+  ],
+  [
+    {'surah': 6, 'start': 69, 'end': 73},
+  ],
+  [
+    {'surah': 6, 'start': 74, 'end': 81},
+  ],
+  [
+    {'surah': 6, 'start': 82, 'end': 90},
+  ],
+  [
+    {'surah': 6, 'start': 91, 'end': 94},
+  ],
+  [
+    {'surah': 6, 'start': 95, 'end': 101},
+  ],
+  [
+    {'surah': 6, 'start': 102, 'end': 110},
+  ],
+  [
+    {'surah': 6, 'start': 111, 'end': 118},
+  ],
+  [
+    {'surah': 6, 'start': 119, 'end': 124},
+  ],
+  [
+    {'surah': 6, 'start': 125, 'end': 131},
+  ],
+  [
+    {'surah': 6, 'start': 132, 'end': 137},
+  ],
+  [
+    {'surah': 6, 'start': 138, 'end': 142},
+  ],
+  [
+    {'surah': 6, 'start': 143, 'end': 146},
+  ],
+  [
+    {'surah': 6, 'start': 147, 'end': 151},
+  ],
+  [
+    {'surah': 6, 'start': 152, 'end': 157},
+  ],
+  [
+    {'surah': 6, 'start': 158, 'end': 165},
+  ],
+  [
+    {'surah': 7, 'start': 1, 'end': 11},
+  ],
+  [
+    {'surah': 7, 'start': 12, 'end': 22},
+  ],
+  [
+    {'surah': 7, 'start': 23, 'end': 30},
+  ],
+  [
+    {'surah': 7, 'start': 31, 'end': 37},
+  ],
+  [
+    {'surah': 7, 'start': 38, 'end': 43},
+  ],
+  [
+    {'surah': 7, 'start': 44, 'end': 51},
+  ],
+  [
+    {'surah': 7, 'start': 52, 'end': 57},
+  ],
+  [
+    {'surah': 7, 'start': 58, 'end': 67},
+  ],
+  [
+    {'surah': 7, 'start': 68, 'end': 73},
+  ],
+  [
+    {'surah': 7, 'start': 74, 'end': 81},
+  ],
+  [
+    {'surah': 7, 'start': 82, 'end': 87},
+  ],
+  [
+    {'surah': 7, 'start': 88, 'end': 95},
+  ],
+  [
+    {'surah': 7, 'start': 96, 'end': 104},
+  ],
+  [
+    {'surah': 7, 'start': 105, 'end': 120},
+  ],
+  [
+    {'surah': 7, 'start': 121, 'end': 130},
+  ],
+  [
+    {'surah': 7, 'start': 131, 'end': 137},
+  ],
+  [
+    {'surah': 7, 'start': 138, 'end': 143},
+  ],
+  [
+    {'surah': 7, 'start': 144, 'end': 149},
+  ],
+  [
+    {'surah': 7, 'start': 150, 'end': 155},
+  ],
+  [
+    {'surah': 7, 'start': 156, 'end': 159},
+  ],
+  [
+    {'surah': 7, 'start': 160, 'end': 163},
+  ],
+  [
+    {'surah': 7, 'start': 164, 'end': 170},
+  ],
+  [
+    {'surah': 7, 'start': 171, 'end': 178},
+  ],
+  [
+    {'surah': 7, 'start': 179, 'end': 187},
+  ],
+  [
+    {'surah': 7, 'start': 188, 'end': 195},
+  ],
+  [
+    {'surah': 7, 'start': 196, 'end': 206},
+  ],
+  [
+    {'surah': 8, 'start': 1, 'end': 8},
+  ],
+  [
+    {'surah': 8, 'start': 9, 'end': 16},
+  ],
+  [
+    {'surah': 8, 'start': 17, 'end': 25},
+  ],
+  [
+    {'surah': 8, 'start': 26, 'end': 33},
+  ],
+  [
+    {'surah': 8, 'start': 34, 'end': 40},
+  ],
+  [
+    {'surah': 8, 'start': 41, 'end': 45},
+  ],
+  [
+    {'surah': 8, 'start': 46, 'end': 52},
+  ],
+  [
+    {'surah': 8, 'start': 53, 'end': 61},
+  ],
+  [
+    {'surah': 8, 'start': 62, 'end': 69},
+  ],
+  [
+    {'surah': 8, 'start': 70, 'end': 75},
+  ],
+  [
+    {'surah': 9, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 9, 'start': 7, 'end': 13},
+  ],
+  [
+    {'surah': 9, 'start': 14, 'end': 20},
+  ],
+  [
+    {'surah': 9, 'start': 21, 'end': 26},
+  ],
+  [
+    {'surah': 9, 'start': 27, 'end': 31},
+  ],
+  [
+    {'surah': 9, 'start': 32, 'end': 36},
+  ],
+  [
+    {'surah': 9, 'start': 37, 'end': 40},
+  ],
+  [
+    {'surah': 9, 'start': 41, 'end': 47},
+  ],
+  [
+    {'surah': 9, 'start': 48, 'end': 54},
+  ],
+  [
+    {'surah': 9, 'start': 55, 'end': 61},
+  ],
+  [
+    {'surah': 9, 'start': 62, 'end': 68},
+  ],
+  [
+    {'surah': 9, 'start': 69, 'end': 72},
+  ],
+  [
+    {'surah': 9, 'start': 73, 'end': 79},
+  ],
+  [
+    {'surah': 9, 'start': 80, 'end': 86},
+  ],
+  [
+    {'surah': 9, 'start': 87, 'end': 93},
+  ],
+  [
+    {'surah': 9, 'start': 94, 'end': 99},
+  ],
+  [
+    {'surah': 9, 'start': 100, 'end': 106},
+  ],
+  [
+    {'surah': 9, 'start': 107, 'end': 111},
+  ],
+  [
+    {'surah': 9, 'start': 112, 'end': 117},
+  ],
+  [
+    {'surah': 9, 'start': 118, 'end': 122},
+  ],
+  [
+    {'surah': 9, 'start': 123, 'end': 129},
+  ],
+  [
+    {'surah': 10, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 10, 'start': 7, 'end': 14},
+  ],
+  [
+    {'surah': 10, 'start': 15, 'end': 20},
+  ],
+  [
+    {'surah': 10, 'start': 21, 'end': 25},
+  ],
+  [
+    {'surah': 10, 'start': 26, 'end': 33},
+  ],
+  [
+    {'surah': 10, 'start': 34, 'end': 42},
+  ],
+  [
+    {'surah': 10, 'start': 43, 'end': 53},
+  ],
+  [
+    {'surah': 10, 'start': 54, 'end': 61},
+  ],
+  [
+    {'surah': 10, 'start': 62, 'end': 70},
+  ],
+  [
+    {'surah': 10, 'start': 71, 'end': 78},
+  ],
+  [
+    {'surah': 10, 'start': 79, 'end': 88},
+  ],
+  [
+    {'surah': 10, 'start': 89, 'end': 97},
+  ],
+  [
+    {'surah': 10, 'start': 98, 'end': 106},
+  ],
+  [
+    {'surah': 10, 'start': 107, 'end': 109},
+    {'surah': 11, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 11, 'start': 6, 'end': 12},
+  ],
+  [
+    {'surah': 11, 'start': 13, 'end': 19},
+  ],
+  [
+    {'surah': 11, 'start': 20, 'end': 28},
+  ],
+  [
+    {'surah': 11, 'start': 29, 'end': 37},
+  ],
+  [
+    {'surah': 11, 'start': 38, 'end': 45},
+  ],
+  [
+    {'surah': 11, 'start': 46, 'end': 53},
+  ],
+  [
+    {'surah': 11, 'start': 54, 'end': 62},
+  ],
+  [
+    {'surah': 11, 'start': 63, 'end': 71},
+  ],
+  [
+    {'surah': 11, 'start': 72, 'end': 81},
+  ],
+  [
+    {'surah': 11, 'start': 82, 'end': 88},
+  ],
+  [
+    {'surah': 11, 'start': 89, 'end': 97},
+  ],
+  [
+    {'surah': 11, 'start': 98, 'end': 108},
+  ],
+  [
+    {'surah': 11, 'start': 109, 'end': 117},
+  ],
+  [
+    {'surah': 11, 'start': 118, 'end': 123},
+    {'surah': 12, 'start': 1, 'end': 4},
+  ],
+  [
+    {'surah': 12, 'start': 5, 'end': 14},
+  ],
+  [
+    {'surah': 12, 'start': 15, 'end': 22},
+  ],
+  [
+    {'surah': 12, 'start': 23, 'end': 30},
+  ],
+  [
+    {'surah': 12, 'start': 31, 'end': 37},
+  ],
+  [
+    {'surah': 12, 'start': 38, 'end': 43},
+  ],
+  [
+    {'surah': 12, 'start': 44, 'end': 52},
+  ],
+  [
+    {'surah': 12, 'start': 53, 'end': 63},
+  ],
+  [
+    {'surah': 12, 'start': 64, 'end': 69},
+  ],
+  [
+    {'surah': 12, 'start': 70, 'end': 78},
+  ],
+  [
+    {'surah': 12, 'start': 79, 'end': 86},
+  ],
+  [
+    {'surah': 12, 'start': 87, 'end': 95},
+  ],
+  [
+    {'surah': 12, 'start': 96, 'end': 103},
+  ],
+  [
+    {'surah': 12, 'start': 104, 'end': 111},
+  ],
+  [
+    {'surah': 13, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 13, 'start': 6, 'end': 13},
+  ],
+  [
+    {'surah': 13, 'start': 14, 'end': 18},
+  ],
+  [
+    {'surah': 13, 'start': 19, 'end': 28},
+  ],
+  [
+    {'surah': 13, 'start': 29, 'end': 34},
+  ],
+  [
+    {'surah': 13, 'start': 35, 'end': 42},
+  ],
+  [
+    {'surah': 13, 'start': 43, 'end': 43},
+    {'surah': 14, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 14, 'start': 6, 'end': 10},
+  ],
+  [
+    {'surah': 14, 'start': 11, 'end': 18},
+  ],
+  [
+    {'surah': 14, 'start': 19, 'end': 24},
+  ],
+  [
+    {'surah': 14, 'start': 25, 'end': 33},
+  ],
+  [
+    {'surah': 14, 'start': 34, 'end': 42},
+  ],
+  [
+    {'surah': 14, 'start': 43, 'end': 52},
+  ],
+  [
+    {'surah': 15, 'start': 1, 'end': 15},
+  ],
+  [
+    {'surah': 15, 'start': 16, 'end': 31},
+  ],
+  [
+    {'surah': 15, 'start': 32, 'end': 51},
+  ],
+  [
+    {'surah': 15, 'start': 52, 'end': 70},
+  ],
+  [
+    {'surah': 15, 'start': 71, 'end': 90},
+  ],
+  [
+    {'surah': 15, 'start': 91, 'end': 99},
+    {'surah': 16, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 16, 'start': 7, 'end': 14},
+  ],
+  [
+    {'surah': 16, 'start': 15, 'end': 26},
+  ],
+  [
+    {'surah': 16, 'start': 27, 'end': 34},
+  ],
+  [
+    {'surah': 16, 'start': 35, 'end': 42},
+  ],
+  [
+    {'surah': 16, 'start': 43, 'end': 54},
+  ],
+  [
+    {'surah': 16, 'start': 55, 'end': 64},
+  ],
+  [
+    {'surah': 16, 'start': 65, 'end': 72},
+  ],
+  [
+    {'surah': 16, 'start': 73, 'end': 79},
+  ],
+  [
+    {'surah': 16, 'start': 80, 'end': 87},
+  ],
+  [
+    {'surah': 16, 'start': 88, 'end': 93},
+  ],
+  [
+    {'surah': 16, 'start': 94, 'end': 102},
+  ],
+  [
+    {'surah': 16, 'start': 103, 'end': 110},
+  ],
+  [
+    {'surah': 16, 'start': 111, 'end': 118},
+  ],
+  [
+    {'surah': 16, 'start': 119, 'end': 128},
+  ],
+  [
+    {'surah': 17, 'start': 1, 'end': 7},
+  ],
+  [
+    {'surah': 17, 'start': 8, 'end': 17},
+  ],
+  [
+    {'surah': 17, 'start': 18, 'end': 27},
+  ],
+  [
+    {'surah': 17, 'start': 28, 'end': 38},
+  ],
+  [
+    {'surah': 17, 'start': 39, 'end': 49},
+  ],
+  [
+    {'surah': 17, 'start': 50, 'end': 58},
+  ],
+  [
+    {'surah': 17, 'start': 59, 'end': 66},
+  ],
+  [
+    {'surah': 17, 'start': 67, 'end': 75},
+  ],
+  [
+    {'surah': 17, 'start': 76, 'end': 86},
+  ],
+  [
+    {'surah': 17, 'start': 87, 'end': 96},
+  ],
+  [
+    {'surah': 17, 'start': 97, 'end': 104},
+  ],
+  [
+    {'surah': 17, 'start': 105, 'end': 111},
+    {'surah': 18, 'start': 1, 'end': 4},
+  ],
+  [
+    {'surah': 18, 'start': 5, 'end': 15},
+  ],
+  [
+    {'surah': 18, 'start': 16, 'end': 20},
+  ],
+  [
+    {'surah': 18, 'start': 21, 'end': 27},
+  ],
+  [
+    {'surah': 18, 'start': 28, 'end': 34},
+  ],
+  [
+    {'surah': 18, 'start': 35, 'end': 45},
+  ],
+  [
+    {'surah': 18, 'start': 46, 'end': 53},
+  ],
+  [
+    {'surah': 18, 'start': 54, 'end': 61},
+  ],
+  [
+    {'surah': 18, 'start': 62, 'end': 74},
+  ],
+  [
+    {'surah': 18, 'start': 75, 'end': 83},
+  ],
+  [
+    {'surah': 18, 'start': 84, 'end': 97},
+  ],
+  [
+    {'surah': 18, 'start': 98, 'end': 110},
+  ],
+  [
+    {'surah': 19, 'start': 1, 'end': 11},
+  ],
+  [
+    {'surah': 19, 'start': 12, 'end': 25},
+  ],
+  [
+    {'surah': 19, 'start': 26, 'end': 38},
+  ],
+  [
+    {'surah': 19, 'start': 39, 'end': 51},
+  ],
+  [
+    {'surah': 19, 'start': 52, 'end': 64},
+  ],
+  [
+    {'surah': 19, 'start': 65, 'end': 76},
+  ],
+  [
+    {'surah': 19, 'start': 77, 'end': 95},
+  ],
+  [
+    {'surah': 19, 'start': 96, 'end': 98},
+    {'surah': 20, 'start': 1, 'end': 12},
+  ],
+  [
+    {'surah': 20, 'start': 13, 'end': 37},
+  ],
+  [
+    {'surah': 20, 'start': 38, 'end': 51},
+  ],
+  [
+    {'surah': 20, 'start': 52, 'end': 64},
+  ],
+  [
+    {'surah': 20, 'start': 65, 'end': 76},
+  ],
+  [
+    {'surah': 20, 'start': 77, 'end': 87},
+  ],
+  [
+    {'surah': 20, 'start': 88, 'end': 98},
+  ],
+  [
+    {'surah': 20, 'start': 99, 'end': 113},
+  ],
+  [
+    {'surah': 20, 'start': 114, 'end': 125},
+  ],
+  [
+    {'surah': 20, 'start': 126, 'end': 135},
+  ],
+  [
+    {'surah': 21, 'start': 1, 'end': 10},
+  ],
+  [
+    {'surah': 21, 'start': 11, 'end': 24},
+  ],
+  [
+    {'surah': 21, 'start': 25, 'end': 35},
+  ],
+  [
+    {'surah': 21, 'start': 36, 'end': 44},
+  ],
+  [
+    {'surah': 21, 'start': 45, 'end': 57},
+  ],
+  [
+    {'surah': 21, 'start': 58, 'end': 72},
+  ],
+  [
+    {'surah': 21, 'start': 73, 'end': 81},
+  ],
+  [
+    {'surah': 21, 'start': 82, 'end': 90},
+  ],
+  [
+    {'surah': 21, 'start': 91, 'end': 101},
+  ],
+  [
+    {'surah': 21, 'start': 102, 'end': 112},
+  ],
+  [
+    {'surah': 22, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 22, 'start': 6, 'end': 15},
+  ],
+  [
+    {'surah': 22, 'start': 16, 'end': 23},
+  ],
+  [
+    {'surah': 22, 'start': 24, 'end': 30},
+  ],
+  [
+    {'surah': 22, 'start': 31, 'end': 38},
+  ],
+  [
+    {'surah': 22, 'start': 39, 'end': 46},
+  ],
+  [
+    {'surah': 22, 'start': 47, 'end': 55},
+  ],
+  [
+    {'surah': 22, 'start': 56, 'end': 64},
+  ],
+  [
+    {'surah': 22, 'start': 65, 'end': 72},
+  ],
+  [
+    {'surah': 22, 'start': 73, 'end': 78},
+  ],
+  [
+    {'surah': 23, 'start': 1, 'end': 17},
+  ],
+  [
+    {'surah': 23, 'start': 18, 'end': 27},
+  ],
+  [
+    {'surah': 23, 'start': 28, 'end': 42},
+  ],
+  [
+    {'surah': 23, 'start': 43, 'end': 59},
+  ],
+  [
+    {'surah': 23, 'start': 60, 'end': 74},
+  ],
+  [
+    {'surah': 23, 'start': 75, 'end': 89},
+  ],
+  [
+    {'surah': 23, 'start': 90, 'end': 104},
+  ],
+  [
+    {'surah': 23, 'start': 105, 'end': 118},
+  ],
+  [
+    {'surah': 24, 'start': 1, 'end': 10},
+  ],
+  [
+    {'surah': 24, 'start': 11, 'end': 20},
+  ],
+  [
+    {'surah': 24, 'start': 21, 'end': 27},
+  ],
+  [
+    {'surah': 24, 'start': 28, 'end': 31},
+  ],
+  [
+    {'surah': 24, 'start': 32, 'end': 36},
+  ],
+  [
+    {'surah': 24, 'start': 37, 'end': 43},
+  ],
+  [
+    {'surah': 24, 'start': 44, 'end': 53},
+  ],
+  [
+    {'surah': 24, 'start': 54, 'end': 58},
+  ],
+  [
+    {'surah': 24, 'start': 59, 'end': 61},
+  ],
+  [
+    {'surah': 24, 'start': 62, 'end': 64},
+    {'surah': 25, 'start': 1, 'end': 2},
+  ],
+  [
+    {'surah': 25, 'start': 3, 'end': 11},
+  ],
+  [
+    {'surah': 25, 'start': 12, 'end': 20},
+  ],
+  [
+    {'surah': 25, 'start': 21, 'end': 32},
+  ],
+  [
+    {'surah': 25, 'start': 33, 'end': 43},
+  ],
+  [
+    {'surah': 25, 'start': 44, 'end': 55},
+  ],
+  [
+    {'surah': 25, 'start': 56, 'end': 67},
+  ],
+  [
+    {'surah': 25, 'start': 68, 'end': 77},
+  ],
+  [
+    {'surah': 26, 'start': 1, 'end': 19},
+  ],
+  [
+    {'surah': 26, 'start': 20, 'end': 39},
+  ],
+  [
+    {'surah': 26, 'start': 40, 'end': 60},
+  ],
+  [
+    {'surah': 26, 'start': 61, 'end': 83},
+  ],
+  [
+    {'surah': 26, 'start': 84, 'end': 111},
+  ],
+  [
+    {'surah': 26, 'start': 112, 'end': 136},
+  ],
+  [
+    {'surah': 26, 'start': 137, 'end': 159},
+  ],
+  [
+    {'surah': 26, 'start': 160, 'end': 183},
+  ],
+  [
+    {'surah': 26, 'start': 184, 'end': 206},
+  ],
+  [
+    {'surah': 26, 'start': 207, 'end': 227},
+  ],
+  [
+    {'surah': 27, 'start': 1, 'end': 13},
+  ],
+  [
+    {'surah': 27, 'start': 14, 'end': 22},
+  ],
+  [
+    {'surah': 27, 'start': 23, 'end': 35},
+  ],
+  [
+    {'surah': 27, 'start': 36, 'end': 44},
+  ],
+  [
+    {'surah': 27, 'start': 45, 'end': 55},
+  ],
+  [
+    {'surah': 27, 'start': 56, 'end': 63},
+  ],
+  [
+    {'surah': 27, 'start': 64, 'end': 76},
+  ],
+  [
+    {'surah': 27, 'start': 77, 'end': 88},
+  ],
+  [
+    {'surah': 27, 'start': 89, 'end': 93},
+    {'surah': 28, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 28, 'start': 6, 'end': 13},
+  ],
+  [
+    {'surah': 28, 'start': 14, 'end': 21},
+  ],
+  [
+    {'surah': 28, 'start': 22, 'end': 28},
+  ],
+  [
+    {'surah': 28, 'start': 29, 'end': 35},
+  ],
+  [
+    {'surah': 28, 'start': 36, 'end': 43},
+  ],
+  [
+    {'surah': 28, 'start': 44, 'end': 50},
+  ],
+  [
+    {'surah': 28, 'start': 51, 'end': 59},
+  ],
+  [
+    {'surah': 28, 'start': 60, 'end': 70},
+  ],
+  [
+    {'surah': 28, 'start': 71, 'end': 77},
+  ],
+  [
+    {'surah': 28, 'start': 78, 'end': 84},
+  ],
+  [
+    {'surah': 28, 'start': 85, 'end': 88},
+    {'surah': 29, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 29, 'start': 7, 'end': 14},
+  ],
+  [
+    {'surah': 29, 'start': 15, 'end': 23},
+  ],
+  [
+    {'surah': 29, 'start': 24, 'end': 30},
+  ],
+  [
+    {'surah': 29, 'start': 31, 'end': 38},
+  ],
+  [
+    {'surah': 29, 'start': 39, 'end': 45},
+  ],
+  [
+    {'surah': 29, 'start': 46, 'end': 52},
+  ],
+  [
+    {'surah': 29, 'start': 53, 'end': 63},
+  ],
+  [
+    {'surah': 29, 'start': 64, 'end': 69},
+    {'surah': 30, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 30, 'start': 6, 'end': 15},
+  ],
+  [
+    {'surah': 30, 'start': 16, 'end': 24},
+  ],
+  [
+    {'surah': 30, 'start': 25, 'end': 32},
+  ],
+  [
+    {'surah': 30, 'start': 33, 'end': 41},
+  ],
+  [
+    {'surah': 30, 'start': 42, 'end': 50},
+  ],
+  [
+    {'surah': 30, 'start': 51, 'end': 60},
+  ],
+  [
+    {'surah': 31, 'start': 1, 'end': 11},
+  ],
+  [
+    {'surah': 31, 'start': 12, 'end': 19},
+  ],
+  [
+    {'surah': 31, 'start': 20, 'end': 28},
+  ],
+  [
+    {'surah': 31, 'start': 29, 'end': 34},
+  ],
+  [
+    {'surah': 32, 'start': 1, 'end': 11},
+  ],
+  [
+    {'surah': 32, 'start': 12, 'end': 20},
+  ],
+  [
+    {'surah': 32, 'start': 21, 'end': 30},
+  ],
+  [
+    {'surah': 33, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 33, 'start': 7, 'end': 15},
+  ],
+  [
+    {'surah': 33, 'start': 16, 'end': 22},
+  ],
+  [
+    {'surah': 33, 'start': 23, 'end': 30},
+  ],
+  [
+    {'surah': 33, 'start': 31, 'end': 35},
+  ],
+  [
+    {'surah': 33, 'start': 36, 'end': 43},
+  ],
+  [
+    {'surah': 33, 'start': 44, 'end': 50},
+  ],
+  [
+    {'surah': 33, 'start': 51, 'end': 54},
+  ],
+  [
+    {'surah': 33, 'start': 55, 'end': 62},
+  ],
+  [
+    {'surah': 33, 'start': 63, 'end': 73},
+  ],
+  [
+    {'surah': 34, 'start': 1, 'end': 7},
+  ],
+  [
+    {'surah': 34, 'start': 8, 'end': 14},
+  ],
+  [
+    {'surah': 34, 'start': 15, 'end': 22},
+  ],
+  [
+    {'surah': 34, 'start': 23, 'end': 31},
+  ],
+  [
+    {'surah': 34, 'start': 32, 'end': 39},
+  ],
+  [
+    {'surah': 34, 'start': 40, 'end': 48},
+  ],
+  [
+    {'surah': 34, 'start': 49, 'end': 54},
+    {'surah': 35, 'start': 1, 'end': 3},
+  ],
+  [
+    {'surah': 35, 'start': 4, 'end': 11},
+  ],
+  [
+    {'surah': 35, 'start': 12, 'end': 18},
+  ],
+  [
+    {'surah': 35, 'start': 19, 'end': 30},
+  ],
+  [
+    {'surah': 35, 'start': 31, 'end': 38},
+  ],
+  [
+    {'surah': 35, 'start': 39, 'end': 44},
+  ],
+  [
+    {'surah': 35, 'start': 45, 'end': 45},
+    {'surah': 36, 'start': 1, 'end': 12},
+  ],
+  [
+    {'surah': 36, 'start': 13, 'end': 27},
+  ],
+  [
+    {'surah': 36, 'start': 28, 'end': 40},
+  ],
+  [
+    {'surah': 36, 'start': 41, 'end': 54},
+  ],
+  [
+    {'surah': 36, 'start': 55, 'end': 70},
+  ],
+  [
+    {'surah': 36, 'start': 71, 'end': 83},
+  ],
+  [
+    {'surah': 37, 'start': 1, 'end': 24},
+  ],
+  [
+    {'surah': 37, 'start': 25, 'end': 51},
+  ],
+  [
+    {'surah': 37, 'start': 52, 'end': 76},
+  ],
+  [
+    {'surah': 37, 'start': 77, 'end': 102},
+  ],
+  [
+    {'surah': 37, 'start': 103, 'end': 126},
+  ],
+  [
+    {'surah': 37, 'start': 127, 'end': 153},
+  ],
+  [
+    {'surah': 37, 'start': 154, 'end': 182},
+  ],
+  [
+    {'surah': 38, 'start': 1, 'end': 16},
+  ],
+  [
+    {'surah': 38, 'start': 17, 'end': 26},
+  ],
+  [
+    {'surah': 38, 'start': 27, 'end': 42},
+  ],
+  [
+    {'surah': 38, 'start': 43, 'end': 61},
+  ],
+  [
+    {'surah': 38, 'start': 62, 'end': 83},
+  ],
+  [
+    {'surah': 38, 'start': 84, 'end': 88},
+    {'surah': 39, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 39, 'start': 6, 'end': 10},
+  ],
+  [
+    {'surah': 39, 'start': 11, 'end': 21},
+  ],
+  [
+    {'surah': 39, 'start': 22, 'end': 31},
+  ],
+  [
+    {'surah': 39, 'start': 32, 'end': 40},
+  ],
+  [
+    {'surah': 39, 'start': 41, 'end': 47},
+  ],
+  [
+    {'surah': 39, 'start': 48, 'end': 56},
+  ],
+  [
+    {'surah': 39, 'start': 57, 'end': 67},
+  ],
+  [
+    {'surah': 39, 'start': 68, 'end': 74},
+  ],
+  [
+    {'surah': 39, 'start': 75, 'end': 75},
+    {'surah': 40, 'start': 1, 'end': 7},
+  ],
+  [
+    {'surah': 40, 'start': 8, 'end': 16},
+  ],
+  [
+    {'surah': 40, 'start': 17, 'end': 25},
+  ],
+  [
+    {'surah': 40, 'start': 26, 'end': 33},
+  ],
+  [
+    {'surah': 40, 'start': 34, 'end': 40},
+  ],
+  [
+    {'surah': 40, 'start': 41, 'end': 49},
+  ],
+  [
+    {'surah': 40, 'start': 50, 'end': 58},
+  ],
+  [
+    {'surah': 40, 'start': 59, 'end': 66},
+  ],
+  [
+    {'surah': 40, 'start': 67, 'end': 77},
+  ],
+  [
+    {'surah': 40, 'start': 78, 'end': 85},
+  ],
+  [
+    {'surah': 41, 'start': 1, 'end': 11},
+  ],
+  [
+    {'surah': 41, 'start': 12, 'end': 20},
+  ],
+  [
+    {'surah': 41, 'start': 21, 'end': 29},
+  ],
+  [
+    {'surah': 41, 'start': 30, 'end': 38},
+  ],
+  [
+    {'surah': 41, 'start': 39, 'end': 46},
+  ],
+  [
+    {'surah': 41, 'start': 47, 'end': 54},
+  ],
+  [
+    {'surah': 42, 'start': 1, 'end': 10},
+  ],
+  [
+    {'surah': 42, 'start': 11, 'end': 15},
+  ],
+  [
+    {'surah': 42, 'start': 16, 'end': 22},
+  ],
+  [
+    {'surah': 42, 'start': 23, 'end': 31},
+  ],
+  [
+    {'surah': 42, 'start': 32, 'end': 44},
+  ],
+  [
+    {'surah': 42, 'start': 45, 'end': 51},
+  ],
+  [
+    {'surah': 42, 'start': 52, 'end': 53},
+    {'surah': 43, 'start': 1, 'end': 10},
+  ],
+  [
+    {'surah': 43, 'start': 11, 'end': 22},
+  ],
+  [
+    {'surah': 43, 'start': 23, 'end': 33},
+  ],
+  [
+    {'surah': 43, 'start': 34, 'end': 47},
+  ],
+  [
+    {'surah': 43, 'start': 48, 'end': 60},
+  ],
+  [
+    {'surah': 43, 'start': 61, 'end': 73},
+  ],
+  [
+    {'surah': 43, 'start': 74, 'end': 89},
+  ],
+  [
+    {'surah': 44, 'start': 1, 'end': 18},
+  ],
+  [
+    {'surah': 44, 'start': 19, 'end': 39},
+  ],
+  [
+    {'surah': 44, 'start': 40, 'end': 59},
+  ],
+  [
+    {'surah': 45, 'start': 1, 'end': 13},
+  ],
+  [
+    {'surah': 45, 'start': 14, 'end': 22},
+  ],
+  [
+    {'surah': 45, 'start': 23, 'end': 32},
+  ],
+  [
+    {'surah': 45, 'start': 33, 'end': 37},
+    {'surah': 46, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 46, 'start': 6, 'end': 14},
+  ],
+  [
+    {'surah': 46, 'start': 15, 'end': 20},
+  ],
+  [
+    {'surah': 46, 'start': 21, 'end': 28},
+  ],
+  [
+    {'surah': 46, 'start': 29, 'end': 35},
+  ],
+  [
+    {'surah': 47, 'start': 1, 'end': 11},
+  ],
+  [
+    {'surah': 47, 'start': 12, 'end': 19},
+  ],
+  [
+    {'surah': 47, 'start': 20, 'end': 29},
+  ],
+  [
+    {'surah': 47, 'start': 30, 'end': 38},
+  ],
+  [
+    {'surah': 48, 'start': 1, 'end': 9},
+  ],
+  [
+    {'surah': 48, 'start': 10, 'end': 15},
+  ],
+  [
+    {'surah': 48, 'start': 16, 'end': 23},
+  ],
+  [
+    {'surah': 48, 'start': 24, 'end': 28},
+  ],
+  [
+    {'surah': 48, 'start': 29, 'end': 29},
+    {'surah': 49, 'start': 1, 'end': 4},
+  ],
+  [
+    {'surah': 49, 'start': 5, 'end': 11},
+  ],
+  [
+    {'surah': 49, 'start': 12, 'end': 18},
+  ],
+  [
+    {'surah': 50, 'start': 1, 'end': 15},
+  ],
+  [
+    {'surah': 50, 'start': 16, 'end': 35},
+  ],
+  [
+    {'surah': 50, 'start': 36, 'end': 45},
+    {'surah': 51, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 51, 'start': 7, 'end': 30},
+  ],
+  [
+    {'surah': 51, 'start': 31, 'end': 51},
+  ],
+  [
+    {'surah': 51, 'start': 52, 'end': 60},
+    {'surah': 52, 'start': 1, 'end': 14},
+  ],
+  [
+    {'surah': 52, 'start': 15, 'end': 31},
+  ],
+  [
+    {'surah': 52, 'start': 32, 'end': 49},
+  ],
+  [
+    {'surah': 53, 'start': 1, 'end': 26},
+  ],
+  [
+    {'surah': 53, 'start': 27, 'end': 44},
+  ],
+  [
+    {'surah': 53, 'start': 45, 'end': 62},
+    {'surah': 54, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 54, 'start': 7, 'end': 27},
+  ],
+  [
+    {'surah': 54, 'start': 28, 'end': 49},
+  ],
+  [
+    {'surah': 54, 'start': 50, 'end': 55},
+    {'surah': 55, 'start': 1, 'end': 16},
+  ],
+  [
+    {'surah': 55, 'start': 17, 'end': 40},
+  ],
+  [
+    {'surah': 55, 'start': 41, 'end': 67},
+  ],
+  [
+    {'surah': 55, 'start': 68, 'end': 78},
+    {'surah': 56, 'start': 1, 'end': 16},
+  ],
+  [
+    {'surah': 56, 'start': 17, 'end': 50},
+  ],
+  [
+    {'surah': 56, 'start': 51, 'end': 76},
+  ],
+  [
+    {'surah': 56, 'start': 77, 'end': 96},
+    {'surah': 57, 'start': 1, 'end': 3},
+  ],
+  [
+    {'surah': 57, 'start': 4, 'end': 11},
+  ],
+  [
+    {'surah': 57, 'start': 12, 'end': 18},
+  ],
+  [
+    {'surah': 57, 'start': 19, 'end': 24},
+  ],
+  [
+    {'surah': 57, 'start': 25, 'end': 29},
+  ],
+  [
+    {'surah': 58, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 58, 'start': 7, 'end': 11},
+  ],
+  [
+    {'surah': 58, 'start': 12, 'end': 21},
+  ],
+  [
+    {'surah': 58, 'start': 22, 'end': 22},
+    {'surah': 59, 'start': 1, 'end': 3},
+  ],
+  [
+    {'surah': 59, 'start': 4, 'end': 9},
+  ],
+  [
+    {'surah': 59, 'start': 10, 'end': 16},
+  ],
+  [
+    {'surah': 59, 'start': 17, 'end': 24},
+  ],
+  [
+    {'surah': 60, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 60, 'start': 6, 'end': 11},
+  ],
+  [
+    {'surah': 60, 'start': 12, 'end': 13},
+    {'surah': 61, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 61, 'start': 6, 'end': 14},
+  ],
+  [
+    {'surah': 62, 'start': 1, 'end': 8},
+  ],
+  [
+    {'surah': 62, 'start': 9, 'end': 11},
+    {'surah': 63, 'start': 1, 'end': 4},
+  ],
+  [
+    {'surah': 63, 'start': 5, 'end': 11},
+  ],
+  [
+    {'surah': 64, 'start': 1, 'end': 9},
+  ],
+  [
+    {'surah': 64, 'start': 10, 'end': 18},
+  ],
+  [
+    {'surah': 65, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 65, 'start': 6, 'end': 12},
+  ],
+  [
+    {'surah': 66, 'start': 1, 'end': 7},
+  ],
+  [
+    {'surah': 66, 'start': 8, 'end': 12},
+  ],
+  [
+    {'surah': 67, 'start': 1, 'end': 12},
+  ],
+  [
+    {'surah': 67, 'start': 13, 'end': 26},
+  ],
+  [
+    {'surah': 67, 'start': 27, 'end': 30},
+    {'surah': 68, 'start': 1, 'end': 15},
+  ],
+  [
+    {'surah': 68, 'start': 16, 'end': 42},
+  ],
+  [
+    {'surah': 68, 'start': 43, 'end': 52},
+    {'surah': 69, 'start': 1, 'end': 8},
+  ],
+  [
+    {'surah': 69, 'start': 9, 'end': 34},
+  ],
+  [
+    {'surah': 69, 'start': 35, 'end': 52},
+    {'surah': 70, 'start': 1, 'end': 10},
+  ],
+  [
+    {'surah': 70, 'start': 11, 'end': 39},
+  ],
+  [
+    {'surah': 70, 'start': 40, 'end': 44},
+    {'surah': 71, 'start': 1, 'end': 10},
+  ],
+  [
+    {'surah': 71, 'start': 11, 'end': 28},
+  ],
+  [
+    {'surah': 72, 'start': 1, 'end': 13},
+  ],
+  [
+    {'surah': 72, 'start': 14, 'end': 28},
+  ],
+  [
+    {'surah': 73, 'start': 1, 'end': 19},
+  ],
+  [
+    {'surah': 73, 'start': 20, 'end': 20},
+    {'surah': 74, 'start': 1, 'end': 17},
+  ],
+  [
+    {'surah': 74, 'start': 18, 'end': 47},
+  ],
+  [
+    {'surah': 74, 'start': 48, 'end': 56},
+    {'surah': 75, 'start': 1, 'end': 19},
+  ],
+  [
+    {'surah': 75, 'start': 20, 'end': 40},
+    {'surah': 76, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 76, 'start': 6, 'end': 25},
+  ],
+  [
+    {'surah': 76, 'start': 26, 'end': 31},
+    {'surah': 77, 'start': 1, 'end': 19},
+  ],
+  [
+    {'surah': 77, 'start': 20, 'end': 50},
+  ],
+  [
+    {'surah': 78, 'start': 1, 'end': 30},
+  ],
+  [
+    {'surah': 78, 'start': 31, 'end': 40},
+    {'surah': 79, 'start': 1, 'end': 15},
+  ],
+  [
+    {'surah': 79, 'start': 16, 'end': 46},
+  ],
+  [
+    {'surah': 80, 'start': 1, 'end': 42},
+  ],
+  [
+    {'surah': 81, 'start': 1, 'end': 29},
+  ],
+  [
+    {'surah': 82, 'start': 1, 'end': 19},
+    {'surah': 83, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 83, 'start': 7, 'end': 34},
+  ],
+  [
+    {'surah': 83, 'start': 35, 'end': 36},
+    {'surah': 84, 'start': 1, 'end': 25},
+  ],
+  [
+    {'surah': 85, 'start': 1, 'end': 22},
+  ],
+  [
+    {'surah': 86, 'start': 1, 'end': 17},
+    {'surah': 87, 'start': 1, 'end': 15},
+  ],
+  [
+    {'surah': 87, 'start': 16, 'end': 19},
+    {'surah': 88, 'start': 1, 'end': 26},
+  ],
+  [
+    {'surah': 89, 'start': 1, 'end': 23},
+  ],
+  [
+    {'surah': 89, 'start': 24, 'end': 30},
+    {'surah': 90, 'start': 1, 'end': 20},
+  ],
+  [
+    {'surah': 91, 'start': 1, 'end': 15},
+    {'surah': 92, 'start': 1, 'end': 14},
+  ],
+  [
+    {'surah': 92, 'start': 15, 'end': 21},
+    {'surah': 93, 'start': 1, 'end': 11},
+    {'surah': 94, 'start': 1, 'end': 8},
+  ],
+  [
+    {'surah': 95, 'start': 1, 'end': 8},
+    {'surah': 96, 'start': 1, 'end': 19},
+  ],
+  [
+    {'surah': 97, 'start': 1, 'end': 5},
+    {'surah': 98, 'start': 1, 'end': 7},
+  ],
+  [
+    {'surah': 98, 'start': 8, 'end': 8},
+    {'surah': 99, 'start': 1, 'end': 8},
+    {'surah': 100, 'start': 1, 'end': 9},
+  ],
+  [
+    {'surah': 100, 'start': 10, 'end': 11},
+    {'surah': 101, 'start': 1, 'end': 11},
+    {'surah': 102, 'start': 1, 'end': 8},
+  ],
+  [
+    {'surah': 103, 'start': 1, 'end': 3},
+    {'surah': 104, 'start': 1, 'end': 9},
+    {'surah': 105, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 106, 'start': 1, 'end': 4},
+    {'surah': 107, 'start': 1, 'end': 7},
+    {'surah': 108, 'start': 1, 'end': 3},
+  ],
+  [
+    {'surah': 109, 'start': 1, 'end': 6},
+    {'surah': 110, 'start': 1, 'end': 3},
+    {'surah': 111, 'start': 1, 'end': 5},
+  ],
+  [
+    {'surah': 112, 'start': 1, 'end': 4},
+    {'surah': 113, 'start': 1, 'end': 5},
+    {'surah': 114, 'start': 1, 'end': 6},
+  ],
+];

--- a/lib/quran/data/warsh_page_data.dart
+++ b/lib/quran/data/warsh_page_data.dart
@@ -1,150 +1,150 @@
-const List<List<Map<String, int>>> pageData = [
+const List<List<Map<String, int>>> warshPageData = [
   [
     {'surah': 1, 'start': 1, 'end': 7},
   ],
   [
-    {'surah': 2, 'start': 1, 'end': 5},
+    {'surah': 2, 'start': 1, 'end': 4},
   ],
   [
-    {'surah': 2, 'start': 6, 'end': 16},
+    {'surah': 2, 'start': 5, 'end': 15},
   ],
   [
-    {'surah': 2, 'start': 17, 'end': 24},
+    {'surah': 2, 'start': 16, 'end': 23},
   ],
   [
-    {'surah': 2, 'start': 25, 'end': 29},
+    {'surah': 2, 'start': 24, 'end': 28},
   ],
   [
-    {'surah': 2, 'start': 30, 'end': 37},
+    {'surah': 2, 'start': 29, 'end': 36},
   ],
   [
-    {'surah': 2, 'start': 38, 'end': 48},
+    {'surah': 2, 'start': 37, 'end': 47},
   ],
   [
-    {'surah': 2, 'start': 49, 'end': 57},
+    {'surah': 2, 'start': 48, 'end': 56},
   ],
   [
-    {'surah': 2, 'start': 58, 'end': 61},
+    {'surah': 2, 'start': 57, 'end': 60},
   ],
   [
-    {'surah': 2, 'start': 62, 'end': 69},
+    {'surah': 2, 'start': 61, 'end': 68},
   ],
   [
-    {'surah': 2, 'start': 70, 'end': 76},
+    {'surah': 2, 'start': 69, 'end': 75},
   ],
   [
-    {'surah': 2, 'start': 77, 'end': 83},
+    {'surah': 2, 'start': 76, 'end': 82},
   ],
   [
-    {'surah': 2, 'start': 84, 'end': 88},
+    {'surah': 2, 'start': 83, 'end': 87},
   ],
   [
-    {'surah': 2, 'start': 89, 'end': 93},
+    {'surah': 2, 'start': 88, 'end': 92},
   ],
   [
-    {'surah': 2, 'start': 94, 'end': 101},
+    {'surah': 2, 'start': 93, 'end': 100},
   ],
   [
-    {'surah': 2, 'start': 102, 'end': 105},
+    {'surah': 2, 'start': 101, 'end': 104},
   ],
   [
-    {'surah': 2, 'start': 106, 'end': 112},
+    {'surah': 2, 'start': 105, 'end': 111},
   ],
   [
-    {'surah': 2, 'start': 113, 'end': 119},
+    {'surah': 2, 'start': 112, 'end': 118},
   ],
   [
-    {'surah': 2, 'start': 120, 'end': 126},
+    {'surah': 2, 'start': 119, 'end': 125},
   ],
   [
-    {'surah': 2, 'start': 127, 'end': 134},
+    {'surah': 2, 'start': 126, 'end': 133},
   ],
   [
-    {'surah': 2, 'start': 135, 'end': 141},
+    {'surah': 2, 'start': 134, 'end': 140},
   ],
   [
-    {'surah': 2, 'start': 142, 'end': 145},
+    {'surah': 2, 'start': 141, 'end': 144},
   ],
   [
-    {'surah': 2, 'start': 146, 'end': 153},
+    {'surah': 2, 'start': 145, 'end': 152},
   ],
   [
-    {'surah': 2, 'start': 154, 'end': 163},
+    {'surah': 2, 'start': 153, 'end': 162},
   ],
   [
-    {'surah': 2, 'start': 164, 'end': 169},
+    {'surah': 2, 'start': 163, 'end': 168},
   ],
   [
-    {'surah': 2, 'start': 170, 'end': 176},
+    {'surah': 2, 'start': 169, 'end': 175},
   ],
   [
-    {'surah': 2, 'start': 177, 'end': 181},
+    {'surah': 2, 'start': 176, 'end': 180},
   ],
   [
-    {'surah': 2, 'start': 182, 'end': 186},
+    {'surah': 2, 'start': 181, 'end': 185},
   ],
   [
-    {'surah': 2, 'start': 187, 'end': 190},
+    {'surah': 2, 'start': 186, 'end': 189},
   ],
   [
-    {'surah': 2, 'start': 191, 'end': 196},
+    {'surah': 2, 'start': 190, 'end': 195},
   ],
   [
-    {'surah': 2, 'start': 197, 'end': 202},
+    {'surah': 2, 'start': 196, 'end': 200},
   ],
   [
-    {'surah': 2, 'start': 203, 'end': 210},
+    {'surah': 2, 'start': 201, 'end': 208},
   ],
   [
-    {'surah': 2, 'start': 211, 'end': 215},
+    {'surah': 2, 'start': 209, 'end': 213},
   ],
   [
-    {'surah': 2, 'start': 216, 'end': 219},
+    {'surah': 2, 'start': 214, 'end': 217},
   ],
   [
-    {'surah': 2, 'start': 220, 'end': 224},
+    {'surah': 2, 'start': 218, 'end': 222},
   ],
   [
-    {'surah': 2, 'start': 225, 'end': 230},
+    {'surah': 2, 'start': 223, 'end': 228},
   ],
   [
-    {'surah': 2, 'start': 231, 'end': 233},
+    {'surah': 2, 'start': 229, 'end': 231},
   ],
   [
-    {'surah': 2, 'start': 234, 'end': 237},
+    {'surah': 2, 'start': 232, 'end': 235},
   ],
   [
-    {'surah': 2, 'start': 238, 'end': 245},
+    {'surah': 2, 'start': 236, 'end': 243},
   ],
   [
-    {'surah': 2, 'start': 246, 'end': 248},
+    {'surah': 2, 'start': 244, 'end': 246},
   ],
   [
-    {'surah': 2, 'start': 249, 'end': 252},
+    {'surah': 2, 'start': 247, 'end': 250},
   ],
   [
-    {'surah': 2, 'start': 253, 'end': 256},
+    {'surah': 2, 'start': 251, 'end': 255},
   ],
   [
-    {'surah': 2, 'start': 257, 'end': 259},
+    {'surah': 2, 'start': 256, 'end': 258},
   ],
   [
-    {'surah': 2, 'start': 260, 'end': 264},
+    {'surah': 2, 'start': 259, 'end': 263},
   ],
   [
-    {'surah': 2, 'start': 265, 'end': 269},
+    {'surah': 2, 'start': 264, 'end': 268},
   ],
   [
-    {'surah': 2, 'start': 270, 'end': 274},
+    {'surah': 2, 'start': 269, 'end': 273},
   ],
   [
-    {'surah': 2, 'start': 275, 'end': 281},
+    {'surah': 2, 'start': 274, 'end': 280},
   ],
   [
-    {'surah': 2, 'start': 282, 'end': 282},
+    {'surah': 2, 'start': 281, 'end': 281},
   ],
   [
-    {'surah': 2, 'start': 283, 'end': 286},
+    {'surah': 2, 'start': 282, 'end': 285},
   ],
   [
     {'surah': 3, 'start': 1, 'end': 9},
@@ -165,25 +165,25 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 3, 'start': 38, 'end': 45},
   ],
   [
-    {'surah': 3, 'start': 46, 'end': 52},
+    {'surah': 3, 'start': 46, 'end': 51},
   ],
   [
-    {'surah': 3, 'start': 53, 'end': 61},
+    {'surah': 3, 'start': 52, 'end': 60},
   ],
   [
-    {'surah': 3, 'start': 62, 'end': 70},
+    {'surah': 3, 'start': 61, 'end': 69},
   ],
   [
-    {'surah': 3, 'start': 71, 'end': 77},
+    {'surah': 3, 'start': 70, 'end': 76},
   ],
   [
-    {'surah': 3, 'start': 78, 'end': 83},
+    {'surah': 3, 'start': 77, 'end': 82},
   ],
   [
-    {'surah': 3, 'start': 84, 'end': 91},
+    {'surah': 3, 'start': 83, 'end': 90},
   ],
   [
-    {'surah': 3, 'start': 92, 'end': 100},
+    {'surah': 3, 'start': 91, 'end': 100},
   ],
   [
     {'surah': 3, 'start': 101, 'end': 108},
@@ -252,251 +252,251 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 4, 'start': 34, 'end': 37},
   ],
   [
-    {'surah': 4, 'start': 38, 'end': 44},
+    {'surah': 4, 'start': 38, 'end': 43},
   ],
   [
-    {'surah': 4, 'start': 45, 'end': 51},
+    {'surah': 4, 'start': 45, 'end': 50},
   ],
   [
-    {'surah': 4, 'start': 52, 'end': 59},
+    {'surah': 4, 'start': 51, 'end': 58},
   ],
   [
-    {'surah': 4, 'start': 60, 'end': 65},
+    {'surah': 4, 'start': 59, 'end': 64},
   ],
   [
-    {'surah': 4, 'start': 66, 'end': 74},
+    {'surah': 4, 'start': 65, 'end': 73},
   ],
   [
-    {'surah': 4, 'start': 75, 'end': 79},
+    {'surah': 4, 'start': 74, 'end': 78},
   ],
   [
-    {'surah': 4, 'start': 80, 'end': 86},
+    {'surah': 4, 'start': 79, 'end': 85},
   ],
   [
-    {'surah': 4, 'start': 87, 'end': 91},
+    {'surah': 4, 'start': 86, 'end': 90},
   ],
   [
-    {'surah': 4, 'start': 92, 'end': 94},
+    {'surah': 4, 'start': 91, 'end': 93},
   ],
   [
-    {'surah': 4, 'start': 95, 'end': 101},
+    {'surah': 4, 'start': 94, 'end': 100},
   ],
   [
-    {'surah': 4, 'start': 102, 'end': 105},
+    {'surah': 4, 'start': 101, 'end': 104},
   ],
   [
-    {'surah': 4, 'start': 106, 'end': 113},
+    {'surah': 4, 'start': 105, 'end': 112},
   ],
   [
-    {'surah': 4, 'start': 114, 'end': 121},
+    {'surah': 4, 'start': 113, 'end': 120},
   ],
   [
-    {'surah': 4, 'start': 122, 'end': 127},
+    {'surah': 4, 'start': 121, 'end': 126},
   ],
   [
-    {'surah': 4, 'start': 128, 'end': 134},
+    {'surah': 4, 'start': 127, 'end': 133},
   ],
   [
-    {'surah': 4, 'start': 135, 'end': 140},
+    {'surah': 4, 'start': 134, 'end': 139},
   ],
   [
-    {'surah': 4, 'start': 141, 'end': 147},
+    {'surah': 4, 'start': 140, 'end': 146},
   ],
   [
-    {'surah': 4, 'start': 148, 'end': 154},
+    {'surah': 4, 'start': 147, 'end': 153},
   ],
   [
-    {'surah': 4, 'start': 155, 'end': 162},
+    {'surah': 4, 'start': 154, 'end': 161},
   ],
   [
-    {'surah': 4, 'start': 163, 'end': 170},
+    {'surah': 4, 'start': 162, 'end': 169},
   ],
   [
-    {'surah': 4, 'start': 171, 'end': 175},
+    {'surah': 4, 'start': 170, 'end': 174},
   ],
   [
-    {'surah': 4, 'start': 176, 'end': 176},
-    {'surah': 5, 'start': 1, 'end': 2},
+    {'surah': 4, 'start': 175, 'end': 175},
+    {'surah': 5, 'start': 1, 'end': 3},
   ],
   [
-    {'surah': 5, 'start': 3, 'end': 5},
+    {'surah': 5, 'start': 4, 'end': 6},
   ],
   [
-    {'surah': 5, 'start': 6, 'end': 9},
+    {'surah': 5, 'start': 7, 'end': 10},
   ],
   [
-    {'surah': 5, 'start': 10, 'end': 13},
+    {'surah': 5, 'start': 11, 'end': 14},
   ],
   [
-    {'surah': 5, 'start': 14, 'end': 17},
+    {'surah': 5, 'start': 15, 'end': 19},
   ],
   [
-    {'surah': 5, 'start': 18, 'end': 23},
+    {'surah': 5, 'start': 20, 'end': 25},
   ],
   [
-    {'surah': 5, 'start': 24, 'end': 31},
+    {'surah': 5, 'start': 26, 'end': 33},
   ],
   [
-    {'surah': 5, 'start': 32, 'end': 36},
+    {'surah': 5, 'start': 34, 'end': 38},
   ],
   [
-    {'surah': 5, 'start': 37, 'end': 41},
+    {'surah': 5, 'start': 39, 'end': 43},
   ],
   [
-    {'surah': 5, 'start': 42, 'end': 45},
+    {'surah': 5, 'start': 44, 'end': 47},
   ],
   [
-    {'surah': 5, 'start': 46, 'end': 50},
+    {'surah': 5, 'start': 48, 'end': 52},
   ],
   [
-    {'surah': 5, 'start': 51, 'end': 57},
+    {'surah': 5, 'start': 53, 'end': 59},
   ],
   [
-    {'surah': 5, 'start': 58, 'end': 64},
+    {'surah': 5, 'start': 60, 'end': 66},
   ],
   [
-    {'surah': 5, 'start': 65, 'end': 70},
+    {'surah': 5, 'start': 67, 'end': 72},
   ],
   [
-    {'surah': 5, 'start': 71, 'end': 76},
+    {'surah': 5, 'start': 73, 'end': 79},
   ],
   [
-    {'surah': 5, 'start': 77, 'end': 82},
+    {'surah': 5, 'start': 80, 'end': 85},
   ],
   [
-    {'surah': 5, 'start': 83, 'end': 89},
+    {'surah': 5, 'start': 86, 'end': 92},
   ],
   [
-    {'surah': 5, 'start': 90, 'end': 95},
+    {'surah': 5, 'start': 93, 'end': 97},
   ],
   [
-    {'surah': 5, 'start': 96, 'end': 103},
+    {'surah': 5, 'start': 98, 'end': 105},
   ],
   [
-    {'surah': 5, 'start': 104, 'end': 108},
+    {'surah': 5, 'start': 106, 'end': 110},
   ],
   [
-    {'surah': 5, 'start': 109, 'end': 113},
+    {'surah': 5, 'start': 111, 'end': 115},
   ],
   [
-    {'surah': 5, 'start': 114, 'end': 120},
+    {'surah': 5, 'start': 116, 'end': 122},
   ],
   [
-    {'surah': 6, 'start': 1, 'end': 8},
+    {'surah': 6, 'start': 1, 'end': 9},
   ],
   [
-    {'surah': 6, 'start': 9, 'end': 18},
+    {'surah': 6, 'start': 10, 'end': 19},
   ],
   [
-    {'surah': 6, 'start': 19, 'end': 27},
+    {'surah': 6, 'start': 20, 'end': 28},
   ],
   [
-    {'surah': 6, 'start': 28, 'end': 35},
+    {'surah': 6, 'start': 29, 'end': 36},
   ],
   [
-    {'surah': 6, 'start': 36, 'end': 44},
+    {'surah': 6, 'start': 37, 'end': 45},
   ],
   [
-    {'surah': 6, 'start': 45, 'end': 52},
+    {'surah': 6, 'start': 46, 'end': 53},
   ],
   [
-    {'surah': 6, 'start': 53, 'end': 59},
+    {'surah': 6, 'start': 54, 'end': 60},
   ],
   [
-    {'surah': 6, 'start': 60, 'end': 68},
+    {'surah': 6, 'start': 61, 'end': 68},
   ],
   [
-    {'surah': 6, 'start': 69, 'end': 73},
+    {'surah': 6, 'start': 69, 'end': 74},
   ],
   [
-    {'surah': 6, 'start': 74, 'end': 81},
+    {'surah': 6, 'start': 75, 'end': 82},
   ],
   [
-    {'surah': 6, 'start': 82, 'end': 90},
+    {'surah': 6, 'start': 83, 'end': 91},
   ],
   [
-    {'surah': 6, 'start': 91, 'end': 94},
+    {'surah': 6, 'start': 92, 'end': 95},
   ],
   [
-    {'surah': 6, 'start': 95, 'end': 101},
+    {'surah': 6, 'start': 96, 'end': 102},
   ],
   [
-    {'surah': 6, 'start': 102, 'end': 110},
+    {'surah': 6, 'start': 103, 'end': 111},
   ],
   [
-    {'surah': 6, 'start': 111, 'end': 118},
+    {'surah': 6, 'start': 112, 'end': 119},
   ],
   [
-    {'surah': 6, 'start': 119, 'end': 124},
+    {'surah': 6, 'start': 120, 'end': 125},
   ],
   [
-    {'surah': 6, 'start': 125, 'end': 131},
+    {'surah': 6, 'start': 126, 'end': 131},
   ],
   [
-    {'surah': 6, 'start': 132, 'end': 137},
+    {'surah': 6, 'start': 132, 'end': 138},
   ],
   [
-    {'surah': 6, 'start': 138, 'end': 142},
+    {'surah': 6, 'start': 139, 'end': 143},
   ],
   [
-    {'surah': 6, 'start': 143, 'end': 146},
+    {'surah': 6, 'start': 144, 'end': 147},
   ],
   [
-    {'surah': 6, 'start': 147, 'end': 151},
+    {'surah': 6, 'start': 148, 'end': 152},
   ],
   [
-    {'surah': 6, 'start': 152, 'end': 157},
+    {'surah': 6, 'start': 153, 'end': 158},
   ],
   [
-    {'surah': 6, 'start': 158, 'end': 165},
+    {'surah': 6, 'start': 159, 'end': 167},
   ],
   [
-    {'surah': 7, 'start': 1, 'end': 11},
+    {'surah': 7, 'start': 1, 'end': 10},
   ],
   [
-    {'surah': 7, 'start': 12, 'end': 22},
+    {'surah': 7, 'start': 11, 'end': 21},
   ],
   [
-    {'surah': 7, 'start': 23, 'end': 30},
+    {'surah': 7, 'start': 22, 'end': 28},
   ],
   [
-    {'surah': 7, 'start': 31, 'end': 37},
+    {'surah': 7, 'start': 29, 'end': 35},
   ],
   [
-    {'surah': 7, 'start': 38, 'end': 43},
+    {'surah': 7, 'start': 36, 'end': 42},
   ],
   [
-    {'surah': 7, 'start': 44, 'end': 51},
+    {'surah': 7, 'start': 43, 'end': 50},
   ],
   [
-    {'surah': 7, 'start': 52, 'end': 57},
+    {'surah': 7, 'start': 51, 'end': 56},
   ],
   [
-    {'surah': 7, 'start': 58, 'end': 67},
+    {'surah': 7, 'start': 57, 'end': 66},
   ],
   [
-    {'surah': 7, 'start': 68, 'end': 73},
+    {'surah': 7, 'start': 67, 'end': 72},
   ],
   [
-    {'surah': 7, 'start': 74, 'end': 81},
+    {'surah': 7, 'start': 73, 'end': 80},
   ],
   [
-    {'surah': 7, 'start': 82, 'end': 87},
+    {'surah': 7, 'start': 81, 'end': 86},
   ],
   [
-    {'surah': 7, 'start': 88, 'end': 95},
+    {'surah': 7, 'start': 87, 'end': 94},
   ],
   [
-    {'surah': 7, 'start': 96, 'end': 104},
+    {'surah': 7, 'start': 95, 'end': 103},
   ],
   [
-    {'surah': 7, 'start': 105, 'end': 120},
+    {'surah': 7, 'start': 104, 'end': 119},
   ],
   [
-    {'surah': 7, 'start': 121, 'end': 130},
+    {'surah': 7, 'start': 120, 'end': 129},
   ],
   [
-    {'surah': 7, 'start': 131, 'end': 137},
+    {'surah': 7, 'start': 130, 'end': 137},
   ],
   [
     {'surah': 7, 'start': 138, 'end': 143},
@@ -544,19 +544,19 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 8, 'start': 34, 'end': 40},
   ],
   [
-    {'surah': 8, 'start': 41, 'end': 45},
+    {'surah': 8, 'start': 41, 'end': 46},
   ],
   [
-    {'surah': 8, 'start': 46, 'end': 52},
+    {'surah': 8, 'start': 47, 'end': 53},
   ],
   [
-    {'surah': 8, 'start': 53, 'end': 61},
+    {'surah': 8, 'start': 54, 'end': 62},
   ],
   [
-    {'surah': 8, 'start': 62, 'end': 69},
+    {'surah': 8, 'start': 63, 'end': 70},
   ],
   [
-    {'surah': 8, 'start': 70, 'end': 75},
+    {'surah': 8, 'start': 71, 'end': 76},
   ],
   [
     {'surah': 9, 'start': 1, 'end': 6},
@@ -592,34 +592,34 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 9, 'start': 62, 'end': 68},
   ],
   [
-    {'surah': 9, 'start': 69, 'end': 72},
+    {'surah': 9, 'start': 69, 'end': 73},
   ],
   [
-    {'surah': 9, 'start': 73, 'end': 79},
+    {'surah': 9, 'start': 74, 'end': 80},
   ],
   [
-    {'surah': 9, 'start': 80, 'end': 86},
+    {'surah': 9, 'start': 81, 'end': 87},
   ],
   [
-    {'surah': 9, 'start': 87, 'end': 93},
+    {'surah': 9, 'start': 88, 'end': 94},
   ],
   [
-    {'surah': 9, 'start': 94, 'end': 99},
+    {'surah': 9, 'start': 95, 'end': 100},
   ],
   [
-    {'surah': 9, 'start': 100, 'end': 106},
+    {'surah': 9, 'start': 101, 'end': 107},
   ],
   [
-    {'surah': 9, 'start': 107, 'end': 111},
+    {'surah': 9, 'start': 108, 'end': 112},
   ],
   [
-    {'surah': 9, 'start': 112, 'end': 117},
+    {'surah': 9, 'start': 113, 'end': 118},
   ],
   [
-    {'surah': 9, 'start': 118, 'end': 122},
+    {'surah': 9, 'start': 119, 'end': 123},
   ],
   [
-    {'surah': 9, 'start': 123, 'end': 129},
+    {'surah': 9, 'start': 124, 'end': 130},
   ],
   [
     {'surah': 10, 'start': 1, 'end': 6},
@@ -683,16 +683,16 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 11, 'start': 46, 'end': 53},
   ],
   [
-    {'surah': 11, 'start': 54, 'end': 62},
+    {'surah': 11, 'start': 54, 'end': 61},
   ],
   [
-    {'surah': 11, 'start': 63, 'end': 71},
+    {'surah': 11, 'start': 62, 'end': 70},
   ],
   [
-    {'surah': 11, 'start': 72, 'end': 81},
+    {'surah': 11, 'start': 71, 'end': 80},
   ],
   [
-    {'surah': 11, 'start': 82, 'end': 88},
+    {'surah': 11, 'start': 81, 'end': 88},
   ],
   [
     {'surah': 11, 'start': 89, 'end': 97},
@@ -704,7 +704,7 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 11, 'start': 109, 'end': 117},
   ],
   [
-    {'surah': 11, 'start': 118, 'end': 123},
+    {'surah': 11, 'start': 118, 'end': 121},
     {'surah': 12, 'start': 1, 'end': 4},
   ],
   [
@@ -747,44 +747,44 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 12, 'start': 104, 'end': 111},
   ],
   [
-    {'surah': 13, 'start': 1, 'end': 5},
+    {'surah': 13, 'start': 1, 'end': 6},
   ],
   [
-    {'surah': 13, 'start': 6, 'end': 13},
+    {'surah': 13, 'start': 7, 'end': 14},
   ],
   [
-    {'surah': 13, 'start': 14, 'end': 18},
+    {'surah': 13, 'start': 15, 'end': 20},
   ],
   [
-    {'surah': 13, 'start': 19, 'end': 28},
+    {'surah': 13, 'start': 21, 'end': 29},
   ],
   [
-    {'surah': 13, 'start': 29, 'end': 34},
+    {'surah': 13, 'start': 30, 'end': 35},
   ],
   [
-    {'surah': 13, 'start': 35, 'end': 42},
+    {'surah': 13, 'start': 36, 'end': 43},
   ],
   [
-    {'surah': 13, 'start': 43, 'end': 43},
-    {'surah': 14, 'start': 1, 'end': 5},
+    {'surah': 13, 'start': 44, 'end': 44},
+    {'surah': 14, 'start': 1, 'end': 7},
   ],
   [
-    {'surah': 14, 'start': 6, 'end': 10},
+    {'surah': 14, 'start': 8, 'end': 13},
   ],
   [
-    {'surah': 14, 'start': 11, 'end': 18},
+    {'surah': 14, 'start': 14, 'end': 21},
   ],
   [
-    {'surah': 14, 'start': 19, 'end': 24},
+    {'surah': 14, 'start': 22, 'end': 26},
   ],
   [
-    {'surah': 14, 'start': 25, 'end': 33},
+    {'surah': 14, 'start': 27, 'end': 35},
   ],
   [
-    {'surah': 14, 'start': 34, 'end': 42},
+    {'surah': 14, 'start': 36, 'end': 44},
   ],
   [
-    {'surah': 14, 'start': 43, 'end': 52},
+    {'surah': 14, 'start': 45, 'end': 54},
   ],
   [
     {'surah': 15, 'start': 1, 'end': 15},
@@ -881,7 +881,7 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 17, 'start': 97, 'end': 104},
   ],
   [
-    {'surah': 17, 'start': 105, 'end': 111},
+    {'surah': 17, 'start': 105, 'end': 110},
     {'surah': 18, 'start': 1, 'end': 4},
   ],
   [
@@ -897,77 +897,77 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 18, 'start': 28, 'end': 34},
   ],
   [
-    {'surah': 18, 'start': 35, 'end': 45},
+    {'surah': 18, 'start': 35, 'end': 44},
   ],
   [
-    {'surah': 18, 'start': 46, 'end': 53},
+    {'surah': 18, 'start': 45, 'end': 52},
   ],
   [
-    {'surah': 18, 'start': 54, 'end': 61},
+    {'surah': 18, 'start': 53, 'end': 60},
   ],
   [
-    {'surah': 18, 'start': 62, 'end': 74},
+    {'surah': 18, 'start': 61, 'end': 73},
   ],
   [
-    {'surah': 18, 'start': 75, 'end': 83},
+    {'surah': 18, 'start': 74, 'end': 82},
   ],
   [
-    {'surah': 18, 'start': 84, 'end': 97},
+    {'surah': 18, 'start': 83, 'end': 93},
   ],
   [
-    {'surah': 18, 'start': 98, 'end': 110},
+    {'surah': 18, 'start': 94, 'end': 105},
   ],
   [
-    {'surah': 19, 'start': 1, 'end': 11},
+    {'surah': 19, 'start': 1, 'end': 10},
   ],
   [
-    {'surah': 19, 'start': 12, 'end': 25},
+    {'surah': 19, 'start': 11, 'end': 24},
   ],
   [
-    {'surah': 19, 'start': 26, 'end': 38},
+    {'surah': 19, 'start': 25, 'end': 37},
   ],
   [
-    {'surah': 19, 'start': 39, 'end': 51},
+    {'surah': 19, 'start': 38, 'end': 51},
   ],
   [
     {'surah': 19, 'start': 52, 'end': 64},
   ],
   [
-    {'surah': 19, 'start': 65, 'end': 76},
+    {'surah': 19, 'start': 65, 'end': 77},
   ],
   [
-    {'surah': 19, 'start': 77, 'end': 95},
+    {'surah': 19, 'start': 78, 'end': 96},
   ],
   [
-    {'surah': 19, 'start': 96, 'end': 98},
-    {'surah': 20, 'start': 1, 'end': 12},
+    {'surah': 19, 'start': 97, 'end': 99},
+    {'surah': 20, 'start': 1, 'end': 11},
   ],
   [
-    {'surah': 20, 'start': 13, 'end': 37},
+    {'surah': 20, 'start': 12, 'end': 36},
   ],
   [
-    {'surah': 20, 'start': 38, 'end': 51},
+    {'surah': 20, 'start': 37, 'end': 50},
   ],
   [
-    {'surah': 20, 'start': 52, 'end': 64},
+    {'surah': 20, 'start': 51, 'end': 63},
   ],
   [
-    {'surah': 20, 'start': 65, 'end': 76},
+    {'surah': 20, 'start': 64, 'end': 75},
   ],
   [
-    {'surah': 20, 'start': 77, 'end': 87},
+    {'surah': 20, 'start': 76, 'end': 85},
   ],
   [
-    {'surah': 20, 'start': 88, 'end': 98},
+    {'surah': 20, 'start': 87, 'end': 96},
   ],
   [
-    {'surah': 20, 'start': 99, 'end': 113},
+    {'surah': 20, 'start': 97, 'end': 110},
   ],
   [
-    {'surah': 20, 'start': 114, 'end': 125},
+    {'surah': 20, 'start': 111, 'end': 123},
   ],
   [
-    {'surah': 20, 'start': 126, 'end': 135},
+    {'surah': 20, 'start': 124, 'end': 134},
   ],
   [
     {'surah': 21, 'start': 1, 'end': 10},
@@ -985,19 +985,19 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 21, 'start': 45, 'end': 57},
   ],
   [
-    {'surah': 21, 'start': 58, 'end': 72},
+    {'surah': 21, 'start': 58, 'end': 71},
   ],
   [
-    {'surah': 21, 'start': 73, 'end': 81},
+    {'surah': 21, 'start': 72, 'end': 80},
   ],
   [
-    {'surah': 21, 'start': 82, 'end': 90},
+    {'surah': 21, 'start': 81, 'end': 89},
   ],
   [
-    {'surah': 21, 'start': 91, 'end': 101},
+    {'surah': 21, 'start': 90, 'end': 100},
   ],
   [
-    {'surah': 21, 'start': 102, 'end': 112},
+    {'surah': 21, 'start': 101, 'end': 111},
   ],
   [
     {'surah': 22, 'start': 1, 'end': 5},
@@ -1006,28 +1006,28 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 22, 'start': 6, 'end': 15},
   ],
   [
-    {'surah': 22, 'start': 16, 'end': 23},
+    {'surah': 22, 'start': 16, 'end': 21},
   ],
   [
-    {'surah': 22, 'start': 24, 'end': 30},
+    {'surah': 22, 'start': 22, 'end': 28},
   ],
   [
-    {'surah': 22, 'start': 31, 'end': 38},
+    {'surah': 22, 'start': 29, 'end': 36},
   ],
   [
-    {'surah': 22, 'start': 39, 'end': 46},
+    {'surah': 22, 'start': 37, 'end': 44},
   ],
   [
-    {'surah': 22, 'start': 47, 'end': 55},
+    {'surah': 22, 'start': 45, 'end': 53},
   ],
   [
-    {'surah': 22, 'start': 56, 'end': 64},
+    {'surah': 22, 'start': 54, 'end': 62},
   ],
   [
-    {'surah': 22, 'start': 65, 'end': 72},
+    {'surah': 22, 'start': 63, 'end': 70},
   ],
   [
-    {'surah': 22, 'start': 73, 'end': 78},
+    {'surah': 22, 'start': 71, 'end': 76},
   ],
   [
     {'surah': 23, 'start': 1, 'end': 17},
@@ -1039,19 +1039,19 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 23, 'start': 28, 'end': 42},
   ],
   [
-    {'surah': 23, 'start': 43, 'end': 59},
+    {'surah': 23, 'start': 43, 'end': 60},
   ],
   [
-    {'surah': 23, 'start': 60, 'end': 74},
+    {'surah': 23, 'start': 61, 'end': 75},
   ],
   [
-    {'surah': 23, 'start': 75, 'end': 89},
+    {'surah': 23, 'start': 76, 'end': 90},
   ],
   [
-    {'surah': 23, 'start': 90, 'end': 104},
+    {'surah': 23, 'start': 91, 'end': 105},
   ],
   [
-    {'surah': 23, 'start': 105, 'end': 118},
+    {'surah': 23, 'start': 106, 'end': 119},
   ],
   [
     {'surah': 24, 'start': 1, 'end': 10},
@@ -1066,22 +1066,22 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 24, 'start': 28, 'end': 31},
   ],
   [
-    {'surah': 24, 'start': 32, 'end': 36},
+    {'surah': 24, 'start': 32, 'end': 35},
   ],
   [
-    {'surah': 24, 'start': 37, 'end': 43},
+    {'surah': 24, 'start': 37, 'end': 41},
   ],
   [
-    {'surah': 24, 'start': 44, 'end': 53},
+    {'surah': 24, 'start': 43, 'end': 51},
   ],
   [
-    {'surah': 24, 'start': 54, 'end': 58},
+    {'surah': 24, 'start': 52, 'end': 56},
   ],
   [
-    {'surah': 24, 'start': 59, 'end': 61},
+    {'surah': 24, 'start': 57, 'end': 59},
   ],
   [
-    {'surah': 24, 'start': 62, 'end': 64},
+    {'surah': 24, 'start': 60, 'end': 62},
     {'surah': 25, 'start': 1, 'end': 2},
   ],
   [
@@ -1106,13 +1106,13 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 25, 'start': 68, 'end': 77},
   ],
   [
-    {'surah': 26, 'start': 1, 'end': 19},
+    {'surah': 26, 'start': 1, 'end': 18},
   ],
   [
-    {'surah': 26, 'start': 20, 'end': 39},
+    {'surah': 26, 'start': 19, 'end': 38},
   ],
   [
-    {'surah': 26, 'start': 40, 'end': 60},
+    {'surah': 26, 'start': 39, 'end': 60},
   ],
   [
     {'surah': 26, 'start': 61, 'end': 83},
@@ -1133,7 +1133,7 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 26, 'start': 184, 'end': 206},
   ],
   [
-    {'surah': 26, 'start': 207, 'end': 227},
+    {'surah': 26, 'start': 207, 'end': 226},
   ],
   [
     {'surah': 27, 'start': 1, 'end': 13},
@@ -1142,35 +1142,35 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 27, 'start': 14, 'end': 22},
   ],
   [
-    {'surah': 27, 'start': 23, 'end': 35},
+    {'surah': 27, 'start': 23, 'end': 36},
   ],
   [
-    {'surah': 27, 'start': 36, 'end': 44},
+    {'surah': 27, 'start': 37, 'end': 46},
   ],
   [
-    {'surah': 27, 'start': 45, 'end': 55},
+    {'surah': 27, 'start': 47, 'end': 57},
   ],
   [
-    {'surah': 27, 'start': 56, 'end': 63},
+    {'surah': 27, 'start': 58, 'end': 65},
   ],
   [
-    {'surah': 27, 'start': 64, 'end': 76},
+    {'surah': 27, 'start': 66, 'end': 78},
   ],
   [
-    {'surah': 27, 'start': 77, 'end': 88},
+    {'surah': 27, 'start': 79, 'end': 90},
   ],
   [
-    {'surah': 27, 'start': 89, 'end': 93},
-    {'surah': 28, 'start': 1, 'end': 5},
+    {'surah': 27, 'start': 91, 'end': 95},
+    {'surah': 28, 'start': 1, 'end': 4},
   ],
   [
-    {'surah': 28, 'start': 6, 'end': 13},
+    {'surah': 28, 'start': 5, 'end': 12},
   ],
   [
-    {'surah': 28, 'start': 14, 'end': 21},
+    {'surah': 28, 'start': 13, 'end': 20},
   ],
   [
-    {'surah': 28, 'start': 22, 'end': 28},
+    {'surah': 28, 'start': 21, 'end': 28},
   ],
   [
     {'surah': 28, 'start': 29, 'end': 35},
@@ -1195,16 +1195,16 @@ const List<List<Map<String, int>>> pageData = [
   ],
   [
     {'surah': 28, 'start': 85, 'end': 88},
-    {'surah': 29, 'start': 1, 'end': 6},
+    {'surah': 29, 'start': 1, 'end': 5},
   ],
   [
-    {'surah': 29, 'start': 7, 'end': 14},
+    {'surah': 29, 'start': 6, 'end': 13},
   ],
   [
-    {'surah': 29, 'start': 15, 'end': 23},
+    {'surah': 29, 'start': 14, 'end': 22},
   ],
   [
-    {'surah': 29, 'start': 24, 'end': 30},
+    {'surah': 29, 'start': 23, 'end': 30},
   ],
   [
     {'surah': 29, 'start': 31, 'end': 38},
@@ -1220,37 +1220,37 @@ const List<List<Map<String, int>>> pageData = [
   ],
   [
     {'surah': 29, 'start': 64, 'end': 69},
-    {'surah': 30, 'start': 1, 'end': 5},
+    {'surah': 30, 'start': 1, 'end': 4},
   ],
   [
-    {'surah': 30, 'start': 6, 'end': 15},
+    {'surah': 30, 'start': 5, 'end': 14},
   ],
   [
-    {'surah': 30, 'start': 16, 'end': 24},
+    {'surah': 30, 'start': 15, 'end': 23},
   ],
   [
-    {'surah': 30, 'start': 25, 'end': 32},
+    {'surah': 30, 'start': 24, 'end': 31},
   ],
   [
-    {'surah': 30, 'start': 33, 'end': 41},
+    {'surah': 30, 'start': 32, 'end': 40},
   ],
   [
-    {'surah': 30, 'start': 42, 'end': 50},
+    {'surah': 30, 'start': 41, 'end': 49},
   ],
   [
-    {'surah': 30, 'start': 51, 'end': 60},
+    {'surah': 30, 'start': 50, 'end': 59},
   ],
   [
-    {'surah': 31, 'start': 1, 'end': 11},
+    {'surah': 31, 'start': 1, 'end': 10},
   ],
   [
-    {'surah': 31, 'start': 12, 'end': 19},
+    {'surah': 31, 'start': 11, 'end': 18},
   ],
   [
-    {'surah': 31, 'start': 20, 'end': 28},
+    {'surah': 31, 'start': 19, 'end': 27},
   ],
   [
-    {'surah': 31, 'start': 29, 'end': 34},
+    {'surah': 31, 'start': 28, 'end': 33},
   ],
   [
     {'surah': 32, 'start': 1, 'end': 11},
@@ -1326,26 +1326,26 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 35, 'start': 31, 'end': 38},
   ],
   [
-    {'surah': 35, 'start': 39, 'end': 44},
+    {'surah': 35, 'start': 39, 'end': 45},
   ],
   [
-    {'surah': 35, 'start': 45, 'end': 45},
-    {'surah': 36, 'start': 1, 'end': 12},
+    {'surah': 35, 'start': 46, 'end': 46},
+    {'surah': 36, 'start': 1, 'end': 11},
   ],
   [
-    {'surah': 36, 'start': 13, 'end': 27},
+    {'surah': 36, 'start': 12, 'end': 26},
   ],
   [
-    {'surah': 36, 'start': 28, 'end': 40},
+    {'surah': 36, 'start': 27, 'end': 39},
   ],
   [
-    {'surah': 36, 'start': 41, 'end': 54},
+    {'surah': 36, 'start': 40, 'end': 53},
   ],
   [
-    {'surah': 36, 'start': 55, 'end': 70},
+    {'surah': 36, 'start': 54, 'end': 69},
   ],
   [
-    {'surah': 36, 'start': 71, 'end': 83},
+    {'surah': 36, 'start': 70, 'end': 82},
   ],
   [
     {'surah': 37, 'start': 1, 'end': 24},
@@ -1369,57 +1369,57 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 37, 'start': 154, 'end': 182},
   ],
   [
-    {'surah': 38, 'start': 1, 'end': 16},
+    {'surah': 38, 'start': 1, 'end': 15},
   ],
   [
-    {'surah': 38, 'start': 17, 'end': 26},
+    {'surah': 38, 'start': 16, 'end': 25},
   ],
   [
-    {'surah': 38, 'start': 27, 'end': 42},
+    {'surah': 38, 'start': 26, 'end': 41},
   ],
   [
-    {'surah': 38, 'start': 43, 'end': 61},
+    {'surah': 38, 'start': 42, 'end': 60},
   ],
   [
-    {'surah': 38, 'start': 62, 'end': 83},
+    {'surah': 38, 'start': 61, 'end': 82},
   ],
   [
-    {'surah': 38, 'start': 84, 'end': 88},
-    {'surah': 39, 'start': 1, 'end': 5},
+    {'surah': 38, 'start': 83, 'end': 86},
+    {'surah': 39, 'start': 1, 'end': 6},
   ],
   [
-    {'surah': 39, 'start': 6, 'end': 10},
+    {'surah': 39, 'start': 7, 'end': 11},
   ],
   [
-    {'surah': 39, 'start': 11, 'end': 21},
+    {'surah': 39, 'start': 12, 'end': 20},
   ],
   [
-    {'surah': 39, 'start': 22, 'end': 31},
+    {'surah': 39, 'start': 21, 'end': 30},
   ],
   [
-    {'surah': 39, 'start': 32, 'end': 40},
+    {'surah': 39, 'start': 31, 'end': 37},
   ],
   [
-    {'surah': 39, 'start': 41, 'end': 47},
+    {'surah': 39, 'start': 38, 'end': 44},
   ],
   [
-    {'surah': 39, 'start': 48, 'end': 56},
+    {'surah': 39, 'start': 45, 'end': 53},
   ],
   [
-    {'surah': 39, 'start': 57, 'end': 67},
+    {'surah': 39, 'start': 54, 'end': 64},
   ],
   [
-    {'surah': 39, 'start': 68, 'end': 74},
+    {'surah': 39, 'start': 65, 'end': 71},
   ],
   [
-    {'surah': 39, 'start': 75, 'end': 75},
-    {'surah': 40, 'start': 1, 'end': 7},
+    {'surah': 39, 'start': 72, 'end': 72},
+    {'surah': 40, 'start': 1, 'end': 6},
   ],
   [
-    {'surah': 40, 'start': 8, 'end': 16},
+    {'surah': 40, 'start': 7, 'end': 15},
   ],
   [
-    {'surah': 40, 'start': 17, 'end': 25},
+    {'surah': 40, 'start': 16, 'end': 25},
   ],
   [
     {'surah': 40, 'start': 26, 'end': 33},
@@ -1437,62 +1437,62 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 40, 'start': 59, 'end': 66},
   ],
   [
-    {'surah': 40, 'start': 67, 'end': 77},
+    {'surah': 40, 'start': 67, 'end': 76},
   ],
   [
-    {'surah': 40, 'start': 78, 'end': 85},
+    {'surah': 40, 'start': 77, 'end': 84},
   ],
   [
-    {'surah': 41, 'start': 1, 'end': 11},
+    {'surah': 41, 'start': 1, 'end': 10},
   ],
   [
-    {'surah': 41, 'start': 12, 'end': 20},
+    {'surah': 41, 'start': 11, 'end': 19},
   ],
   [
-    {'surah': 41, 'start': 21, 'end': 29},
+    {'surah': 41, 'start': 20, 'end': 28},
   ],
   [
-    {'surah': 41, 'start': 30, 'end': 38},
+    {'surah': 41, 'start': 29, 'end': 37},
   ],
   [
-    {'surah': 41, 'start': 39, 'end': 46},
+    {'surah': 41, 'start': 38, 'end': 45},
   ],
   [
-    {'surah': 41, 'start': 47, 'end': 54},
+    {'surah': 41, 'start': 46, 'end': 53},
   ],
   [
-    {'surah': 42, 'start': 1, 'end': 10},
+    {'surah': 42, 'start': 1, 'end': 8},
   ],
   [
-    {'surah': 42, 'start': 11, 'end': 15},
+    {'surah': 42, 'start': 9, 'end': 13},
   ],
   [
-    {'surah': 42, 'start': 16, 'end': 22},
+    {'surah': 42, 'start': 14, 'end': 20},
   ],
   [
-    {'surah': 42, 'start': 23, 'end': 31},
+    {'surah': 42, 'start': 21, 'end': 29},
   ],
   [
-    {'surah': 42, 'start': 32, 'end': 44},
+    {'surah': 42, 'start': 30, 'end': 41},
   ],
   [
-    {'surah': 42, 'start': 45, 'end': 51},
+    {'surah': 42, 'start': 42, 'end': 48},
   ],
   [
-    {'surah': 42, 'start': 52, 'end': 53},
-    {'surah': 43, 'start': 1, 'end': 10},
+    {'surah': 42, 'start': 49, 'end': 50},
+    {'surah': 43, 'start': 1, 'end': 9},
   ],
   [
-    {'surah': 43, 'start': 11, 'end': 22},
+    {'surah': 43, 'start': 10, 'end': 21},
   ],
   [
-    {'surah': 43, 'start': 23, 'end': 33},
+    {'surah': 43, 'start': 22, 'end': 32},
   ],
   [
-    {'surah': 43, 'start': 34, 'end': 47},
+    {'surah': 43, 'start': 33, 'end': 46},
   ],
   [
-    {'surah': 43, 'start': 48, 'end': 60},
+    {'surah': 43, 'start': 47, 'end': 60},
   ],
   [
     {'surah': 43, 'start': 61, 'end': 73},
@@ -1501,50 +1501,50 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 43, 'start': 74, 'end': 89},
   ],
   [
-    {'surah': 44, 'start': 1, 'end': 18},
+    {'surah': 44, 'start': 1, 'end': 17},
   ],
   [
-    {'surah': 44, 'start': 19, 'end': 39},
+    {'surah': 44, 'start': 18, 'end': 37},
   ],
   [
-    {'surah': 44, 'start': 40, 'end': 59},
+    {'surah': 44, 'start': 38, 'end': 56},
   ],
   [
-    {'surah': 45, 'start': 1, 'end': 13},
+    {'surah': 45, 'start': 1, 'end': 12},
   ],
   [
-    {'surah': 45, 'start': 14, 'end': 22},
+    {'surah': 45, 'start': 13, 'end': 21},
   ],
   [
-    {'surah': 45, 'start': 23, 'end': 32},
+    {'surah': 45, 'start': 22, 'end': 31},
   ],
   [
-    {'surah': 45, 'start': 33, 'end': 37},
-    {'surah': 46, 'start': 1, 'end': 5},
+    {'surah': 45, 'start': 32, 'end': 36},
+    {'surah': 46, 'start': 1, 'end': 4},
   ],
   [
-    {'surah': 46, 'start': 6, 'end': 14},
+    {'surah': 46, 'start': 5, 'end': 13},
   ],
   [
-    {'surah': 46, 'start': 15, 'end': 20},
+    {'surah': 46, 'start': 14, 'end': 19},
   ],
   [
-    {'surah': 46, 'start': 21, 'end': 28},
+    {'surah': 46, 'start': 20, 'end': 27},
   ],
   [
-    {'surah': 46, 'start': 29, 'end': 35},
+    {'surah': 46, 'start': 28, 'end': 34},
   ],
   [
-    {'surah': 47, 'start': 1, 'end': 11},
+    {'surah': 47, 'start': 1, 'end': 12},
   ],
   [
-    {'surah': 47, 'start': 12, 'end': 19},
+    {'surah': 47, 'start': 13, 'end': 20},
   ],
   [
-    {'surah': 47, 'start': 20, 'end': 29},
+    {'surah': 47, 'start': 21, 'end': 30},
   ],
   [
-    {'surah': 47, 'start': 30, 'end': 38},
+    {'surah': 47, 'start': 31, 'end': 39},
   ],
   [
     {'surah': 48, 'start': 1, 'end': 9},
@@ -1586,22 +1586,22 @@ const List<List<Map<String, int>>> pageData = [
   ],
   [
     {'surah': 51, 'start': 52, 'end': 60},
-    {'surah': 52, 'start': 1, 'end': 14},
+    {'surah': 52, 'start': 1, 'end': 12},
   ],
   [
-    {'surah': 52, 'start': 15, 'end': 31},
+    {'surah': 52, 'start': 13, 'end': 29},
   ],
   [
-    {'surah': 52, 'start': 32, 'end': 49},
+    {'surah': 52, 'start': 30, 'end': 47},
   ],
   [
     {'surah': 53, 'start': 1, 'end': 26},
   ],
   [
-    {'surah': 53, 'start': 27, 'end': 44},
+    {'surah': 53, 'start': 27, 'end': 43},
   ],
   [
-    {'surah': 53, 'start': 45, 'end': 62},
+    {'surah': 53, 'start': 44, 'end': 61},
     {'surah': 54, 'start': 1, 'end': 6},
   ],
   [
@@ -1618,33 +1618,33 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 55, 'start': 17, 'end': 40},
   ],
   [
-    {'surah': 55, 'start': 41, 'end': 67},
+    {'surah': 55, 'start': 41, 'end': 68},
   ],
   [
-    {'surah': 55, 'start': 68, 'end': 78},
-    {'surah': 56, 'start': 1, 'end': 16},
+    {'surah': 55, 'start': 69, 'end': 77},
+    {'surah': 56, 'start': 1, 'end': 18},
   ],
   [
-    {'surah': 56, 'start': 17, 'end': 50},
+    {'surah': 56, 'start': 19, 'end': 53},
   ],
   [
-    {'surah': 56, 'start': 51, 'end': 76},
+    {'surah': 56, 'start': 54, 'end': 79},
   ],
   [
-    {'surah': 56, 'start': 77, 'end': 96},
+    {'surah': 56, 'start': 80, 'end': 99},
     {'surah': 57, 'start': 1, 'end': 3},
   ],
   [
     {'surah': 57, 'start': 4, 'end': 11},
   ],
   [
-    {'surah': 57, 'start': 12, 'end': 18},
+    {'surah': 57, 'start': 12, 'end': 17},
   ],
   [
-    {'surah': 57, 'start': 19, 'end': 24},
+    {'surah': 57, 'start': 18, 'end': 23},
   ],
   [
-    {'surah': 57, 'start': 25, 'end': 29},
+    {'surah': 57, 'start': 24, 'end': 28},
   ],
   [
     {'surah': 58, 'start': 1, 'end': 6},
@@ -1653,10 +1653,10 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 58, 'start': 7, 'end': 11},
   ],
   [
-    {'surah': 58, 'start': 12, 'end': 21},
+    {'surah': 58, 'start': 12, 'end': 20},
   ],
   [
-    {'surah': 58, 'start': 22, 'end': 22},
+    {'surah': 58, 'start': 21, 'end': 21},
     {'surah': 59, 'start': 1, 'end': 3},
   ],
   [
@@ -1710,38 +1710,38 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 66, 'start': 8, 'end': 12},
   ],
   [
-    {'surah': 67, 'start': 1, 'end': 12},
+    {'surah': 67, 'start': 1, 'end': 13},
   ],
   [
-    {'surah': 67, 'start': 13, 'end': 26},
+    {'surah': 67, 'start': 14, 'end': 27},
   ],
   [
-    {'surah': 67, 'start': 27, 'end': 30},
-    {'surah': 68, 'start': 1, 'end': 15},
+    {'surah': 67, 'start': 28, 'end': 31},
+    {'surah': 68, 'start': 1, 'end': 16},
   ],
   [
-    {'surah': 68, 'start': 16, 'end': 42},
+    {'surah': 68, 'start': 17, 'end': 42},
   ],
   [
     {'surah': 68, 'start': 43, 'end': 52},
-    {'surah': 69, 'start': 1, 'end': 8},
+    {'surah': 69, 'start': 1, 'end': 7},
   ],
   [
-    {'surah': 69, 'start': 9, 'end': 34},
+    {'surah': 69, 'start': 8, 'end': 35},
   ],
   [
-    {'surah': 69, 'start': 35, 'end': 52},
+    {'surah': 69, 'start': 36, 'end': 52},
     {'surah': 70, 'start': 1, 'end': 10},
   ],
   [
-    {'surah': 70, 'start': 11, 'end': 39},
+    {'surah': 70, 'start': 11, 'end': 40},
   ],
   [
-    {'surah': 70, 'start': 40, 'end': 44},
+    {'surah': 70, 'start': 41, 'end': 44},
     {'surah': 71, 'start': 1, 'end': 10},
   ],
   [
-    {'surah': 71, 'start': 11, 'end': 28},
+    {'surah': 71, 'start': 11, 'end': 30},
   ],
   [
     {'surah': 72, 'start': 1, 'end': 13},
@@ -1750,21 +1750,21 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 72, 'start': 14, 'end': 28},
   ],
   [
-    {'surah': 73, 'start': 1, 'end': 19},
+    {'surah': 73, 'start': 1, 'end': 17},
   ],
   [
-    {'surah': 73, 'start': 20, 'end': 20},
-    {'surah': 74, 'start': 1, 'end': 17},
+    {'surah': 73, 'start': 18, 'end': 18},
+    {'surah': 74, 'start': 1, 'end': 18},
   ],
   [
-    {'surah': 74, 'start': 18, 'end': 47},
+    {'surah': 74, 'start': 19, 'end': 46},
   ],
   [
-    {'surah': 74, 'start': 48, 'end': 56},
-    {'surah': 75, 'start': 1, 'end': 19},
+    {'surah': 74, 'start': 47, 'end': 55},
+    {'surah': 75, 'start': 1, 'end': 18},
   ],
   [
-    {'surah': 75, 'start': 20, 'end': 40},
+    {'surah': 75, 'start': 19, 'end': 39},
     {'surah': 76, 'start': 1, 'end': 5},
   ],
   [
@@ -1782,71 +1782,77 @@ const List<List<Map<String, int>>> pageData = [
   ],
   [
     {'surah': 78, 'start': 31, 'end': 40},
-    {'surah': 79, 'start': 1, 'end': 15},
+    {'surah': 79, 'start': 1, 'end': 16},
   ],
   [
-    {'surah': 79, 'start': 16, 'end': 46},
+    {'surah': 79, 'start': 17, 'end': 45},
   ],
   [
-    {'surah': 80, 'start': 1, 'end': 42},
+    {'surah': 80, 'start': 1, 'end': 40},
   ],
   [
+    {'surah': 80, 'start': 41, 'end': 42},
     {'surah': 81, 'start': 1, 'end': 29},
   ],
   [
     {'surah': 82, 'start': 1, 'end': 19},
-    {'surah': 83, 'start': 1, 'end': 6},
+    {'surah': 83, 'start': 1, 'end': 4},
   ],
   [
-    {'surah': 83, 'start': 7, 'end': 34},
+    {'surah': 83, 'start': 5, 'end': 33},
   ],
   [
-    {'surah': 83, 'start': 35, 'end': 36},
-    {'surah': 84, 'start': 1, 'end': 25},
+    {'surah': 83, 'start': 34, 'end': 36},
+    {'surah': 84, 'start': 1, 'end': 24},
   ],
   [
+    {'surah': 84, 'start': 25, 'end': 25},
     {'surah': 85, 'start': 1, 'end': 22},
   ],
   [
     {'surah': 86, 'start': 1, 'end': 17},
-    {'surah': 87, 'start': 1, 'end': 15},
+    {'surah': 87, 'start': 1, 'end': 10},
   ],
   [
-    {'surah': 87, 'start': 16, 'end': 19},
-    {'surah': 88, 'start': 1, 'end': 26},
+    {'surah': 87, 'start': 11, 'end': 19},
+    {'surah': 88, 'start': 1, 'end': 22},
   ],
   [
-    {'surah': 89, 'start': 1, 'end': 23},
+    {'surah': 88, 'start': 23, 'end': 26},
+    {'surah': 89, 'start': 1, 'end': 24},
   ],
   [
-    {'surah': 89, 'start': 24, 'end': 30},
-    {'surah': 90, 'start': 1, 'end': 20},
+    {'surah': 89, 'start': 25, 'end': 32},
+    {'surah': 90, 'start': 1, 'end': 18},
   ],
   [
+    {'surah': 90, 'start': 19, 'end': 20},
     {'surah': 91, 'start': 1, 'end': 15},
-    {'surah': 92, 'start': 1, 'end': 14},
+    {'surah': 92, 'start': 1, 'end': 9},
   ],
   [
-    {'surah': 92, 'start': 15, 'end': 21},
+    {'surah': 92, 'start': 10, 'end': 21},
     {'surah': 93, 'start': 1, 'end': 11},
-    {'surah': 94, 'start': 1, 'end': 8},
+    {'surah': 94, 'start': 1, 'end': 2},
   ],
   [
+    {'surah': 94, 'start': 3, 'end': 8},
     {'surah': 95, 'start': 1, 'end': 8},
-    {'surah': 96, 'start': 1, 'end': 19},
+    {'surah': 96, 'start': 1, 'end': 12},
   ],
   [
+    {'surah': 96, 'start': 13, 'end': 20},
     {'surah': 97, 'start': 1, 'end': 5},
-    {'surah': 98, 'start': 1, 'end': 7},
+    {'surah': 98, 'start': 1, 'end': 5},
   ],
   [
-    {'surah': 98, 'start': 8, 'end': 8},
-    {'surah': 99, 'start': 1, 'end': 8},
-    {'surah': 100, 'start': 1, 'end': 9},
+    {'surah': 98, 'start': 6, 'end': 8},
+    {'surah': 99, 'start': 1, 'end': 9},
+    {'surah': 100, 'start': 1, 'end': 5},
   ],
   [
-    {'surah': 100, 'start': 10, 'end': 11},
-    {'surah': 101, 'start': 1, 'end': 11},
+    {'surah': 100, 'start': 6, 'end': 11},
+    {'surah': 101, 'start': 1, 'end': 10},
     {'surah': 102, 'start': 1, 'end': 8},
   ],
   [
@@ -1855,8 +1861,8 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 105, 'start': 1, 'end': 5},
   ],
   [
-    {'surah': 106, 'start': 1, 'end': 4},
-    {'surah': 107, 'start': 1, 'end': 7},
+    {'surah': 106, 'start': 1, 'end': 5},
+    {'surah': 107, 'start': 1, 'end': 6},
     {'surah': 108, 'start': 1, 'end': 3},
   ],
   [
@@ -1868,5 +1874,10 @@ const List<List<Map<String, int>>> pageData = [
     {'surah': 112, 'start': 1, 'end': 4},
     {'surah': 113, 'start': 1, 'end': 5},
     {'surah': 114, 'start': 1, 'end': 6},
+  ],
+  [
+    {'surah': 4, 'start': 44, 'end': 44},
+    {'surah': 20, 'start': 86, 'end': 86},
+    {'surah': 24, 'start': 36, 'end': 42},
   ],
 ];

--- a/lib/quran/quran.dart
+++ b/lib/quran/quran.dart
@@ -9,19 +9,24 @@ import 'package:my_quran/app/models.dart';
 import 'package:my_quran/quran/data/hizb_data.dart';
 
 import 'package:my_quran/quran/data/juz_data.dart';
-import 'package:my_quran/quran/data/page_data.dart';
+import 'package:my_quran/quran/data/hafs_page_data.dart';
 import 'package:my_quran/quran/data/sajdah_verses.dart';
 import 'package:my_quran/quran/data/surah_data.dart';
+import 'package:my_quran/quran/data/warsh_page_data.dart';
 
 class Quran {
   Quran._();
   static final instance = Quran._();
 
   /// The text displayed to the user (Visual)
-  static final data = ValueNotifier<Map<String, dynamic>>({});
+  ValueNotifier<Map<String, dynamic>> data =
+      ValueNotifier<Map<String, dynamic>>({});
 
   /// The text used for Search Logic (Standard Arabic)
-  static late final Map<String, dynamic> _plainTextData;
+  late Map<String, dynamic> _plainTextData;
+
+  late Map<(int, int), int> _verseToPageMap;
+  late Map<int, List<int>> _surahToPages;
 
   // --- ASSET PATHS ---
   static const String _medinaPath = 'assets/quran.json';
@@ -29,7 +34,7 @@ class Quran {
   static const String _warshPath = 'assets/warsh.json';
 
   /// Helper to get the correct path
-  static String _getPathForFont(FontFamily fontFamily) {
+  String _getPathForFont(FontFamily fontFamily) {
     switch (fontFamily) {
       case FontFamily.rustam:
         return _medinaPath;
@@ -42,7 +47,7 @@ class Quran {
     }
   }
 
-  static Future<Map<String, dynamic>?> _loadJson(String path) async {
+  Future<Map<String, dynamic>?> _loadJson(String path) async {
     try {
       final String jsonString = await rootBundle.loadString(path);
 
@@ -59,40 +64,38 @@ class Quran {
     return json.decode(jsonString) as Map<String, dynamic>;
   }
 
-  static Future<void> initialize({FontFamily? fontFamily}) async {
-    final font = fontFamily ?? FontFamily.defaultFontFamily;
-
-    // 1. Load the Visual Data (What the user reads in the main view)
-    if (await _loadJson(_getPathForFont(font))
-        case final Map<String, dynamic> loadedData) {
-      data.value = loadedData;
-
-      // 2. Load the Logic Data (For Search Results & Highlighting)
-      if (font == FontFamily.warsh) {
-        // CRITICAL: For Warsh, the "Plain Text" is the Warsh data itself.
-        // We indexed this file, so we must display/highlight this file.
-        _plainTextData = loadedData;
-      } else {
-        // For Hafs/Rustam, we keep using the dedicated plain text file (Medina)
-        // because it's cleaner for search snippets.
-        if (font == FontFamily.rustam) {
-          _plainTextData = loadedData;
-        } else {
-          // If we are in Hafs Uthmani, load the Simple/Medina text for search
-          unawaited(
-            _loadJson(_medinaPath).then((v) {
-              _plainTextData = v ?? {};
-            }),
-          );
-        }
-      }
-    }
+  Future<void> initialize({FontFamily? fontFamily}) async {
+    await _applyFont(fontFamily ?? FontFamily.defaultFontFamily);
   }
 
-  static Future<void> useDatasourceForFont(FontFamily fontFamily) async {
-    if (await _loadJson(_getPathForFont(fontFamily))
-        case final Map<String, dynamic> loadedData) {
-      data.value = loadedData;
+  Future<void> useDatasourceForFont(FontFamily fontFamily) async {
+    await _applyFont(fontFamily);
+  }
+
+  void _buildReverseLookups() {
+    _verseToPageMap = {};
+    _surahToPages = {};
+
+    for (int pageIndex = 0; pageIndex < pageData.length; pageIndex++) {
+      final pageNumber = pageIndex + 1;
+      final page = pageData[pageIndex];
+
+      for (final entry in page) {
+        final surah = entry['surah']!;
+        final start = entry['start']!;
+        final end = entry['end']!;
+
+        // Build verse → page map
+        for (int verse = start; verse <= end; verse++) {
+          _verseToPageMap[(surah, verse)] = pageNumber;
+        }
+
+        // Build surah → pages map
+        _surahToPages.putIfAbsent(surah, () => []);
+        if (!_surahToPages[surah]!.contains(pageNumber)) {
+          _surahToPages[surah]!.add(pageNumber);
+        }
+      }
     }
   }
 
@@ -106,6 +109,27 @@ class Quran {
             ),
           )
           .toList(growable: false);
+
+  Future<void> _applyFont(FontFamily fontFamily) async {
+    final loadedData = await _loadJson(_getPathForFont(fontFamily));
+    if (loadedData == null) {
+      throw StateError('Failed to load Quran data.');
+    }
+
+    data.value = loadedData;
+
+    if (fontFamily == FontFamily.warsh) {
+      _plainTextData = loadedData;
+    } else {
+      _plainTextData = await _loadJson(_medinaPath) ?? {};
+    }
+
+    pageData = fontFamily.isWarsh ? warshPageData : hafsPageData;
+
+    _buildReverseLookups();
+  }
+
+  List<List<Map<String, int>>> pageData = [];
 
   ///Takes [pageNumber] and returns a list containing Surahs and the starting
   /// and ending Verse numbers in that page
@@ -125,8 +149,8 @@ class Quran {
   ///
   ///Length of the list is the number of surah in that page.
   List<Map<String, int>> getPageData(int pageNumber) {
-    if (pageNumber < 1 || pageNumber > 604) {
-      throw 'Invalid page number. Page number must be between 1 and 604';
+    if (pageNumber < 1 || pageNumber > totalPagesCount) {
+      throw RangeError.range(pageNumber, 1, totalPagesCount, 'pageNumber');
     }
     return pageData[pageNumber - 1];
   }
@@ -171,14 +195,15 @@ class Quran {
 
   ///Takes [pageNumber] and returns total verses count in that page
   int getVerseCountByPage(int pageNumber) {
-    if (pageNumber < 1 || pageNumber > 604) {
-      throw 'Invalid page number. Page number must be between 1 and 604';
+    if (pageNumber < 1 || pageNumber > totalPagesCount) {
+      throw RangeError.range(pageNumber, 1, totalPagesCount, 'pageNumber');
     }
-    int totalVerseCount = 0;
-    for (int i = 0; i < pageData[pageNumber - 1].length; i++) {
-      totalVerseCount += pageData[pageNumber - 1][i]['end'] ?? 0;
+
+    int total = 0;
+    for (final entry in pageData[pageNumber - 1]) {
+      total += entry['end']! - entry['start']! + 1;
     }
-    return totalVerseCount;
+    return total;
   }
 
   int getJuzNumber(int surahNumber, int verseNumber) {
@@ -206,8 +231,8 @@ class Quran {
 
   ///Takes [surahNumber] and returns the Surah name
   String getSurahName(int surahNumber) {
-    if (surahNumber > 114 || surahNumber <= 0) {
-      throw 'No Surah found with given surahNumber';
+    if (surahNumber < 1 || surahNumber > totalSurahCount) {
+      throw RangeError.range(surahNumber, 1, totalSurahCount, 'surahNumber');
     }
     return surah[surahNumber - 1]['name']! as String;
   }
@@ -215,39 +240,34 @@ class Quran {
   ///Takes [surahNumber] returns the Surah name in Arabic
   String getSurahNameArabic(int surahNumber) {
     if (surahNumber > 114 || surahNumber <= 0) {
-      throw 'No Surah found with given surahNumber';
+      throw RangeError.range(
+        surahNumber,
+        1,
+        totalSurahCount,
+        'No Surah found with given surahNumber',
+      );
     }
     return surah[surahNumber - 1]['arabic']! as String;
   }
 
   ///Takes [surahNumber], [verseNumber] and returns the page number of the Quran
   int getPageNumber(int surahNumber, int verseNumber) {
-    if (surahNumber > 114 || surahNumber <= 0) {
-      throw 'No Surah found with given surahNumber';
+    if (surahNumber < 1 || surahNumber > totalSurahCount) {
+      throw RangeError.range(surahNumber, 1, totalSurahCount, 'surahNumber');
     }
 
-    for (int pageIndex = 0; pageIndex < pageData.length; pageIndex++) {
-      for (
-        int surahIndexInPage = 0;
-        surahIndexInPage < pageData[pageIndex].length;
-        surahIndexInPage++
-      ) {
-        final e = pageData[pageIndex][surahIndexInPage];
-        if (e['surah'] == surahNumber &&
-            e['start']! <= verseNumber &&
-            e['end']! >= verseNumber) {
-          return pageIndex + 1;
-        }
-      }
+    final page = _verseToPageMap[(surahNumber, verseNumber)];
+    if (page == null) {
+      throw ArgumentError('Invalid verse number.');
     }
 
-    throw 'Invalid verse number.';
+    return page;
   }
 
   ///Takes [surahNumber] and returns the place of revelation (Makkah / Madinah) of the surah
   String getPlaceOfRevelation(int surahNumber) {
-    if (surahNumber > 114 || surahNumber <= 0) {
-      throw 'No Surah found with given surahNumber';
+    if (surahNumber < 1 || surahNumber > totalSurahCount) {
+      throw RangeError.range(surahNumber, 1, totalSurahCount, 'surahNumber');
     }
     return surah[surahNumber - 1]['place'].toString();
   }
@@ -267,10 +287,8 @@ class Quran {
     int verseNumber, {
     bool verseEndSymbol = false,
   }) {
-    final verse =
-        (data.value[surahNumber.toString()]
-                as Map<String, dynamic>?)?[verseNumber.toString()]
-            as String?;
+    final surah = data.value[surahNumber.toString()] as Map<String, dynamic>?;
+    final verse = surah?[verseNumber.toString()] as String?;
 
     if (verse == null) {
       throw 'No verse found with given surahNumber and verseNumber.\n\n';
@@ -326,23 +344,11 @@ class Quran {
 
   ///Takes [surahNumber] and returns the list of page numbers of the surah
   List<int> getSurahPages(int surahNumber) {
-    if (surahNumber > 114 || surahNumber <= 0) {
-      throw 'Invalid surahNumber';
+    if (surahNumber < 1 || surahNumber > totalSurahCount) {
+      throw RangeError.range(surahNumber, 1, totalSurahCount, 'surahNumber');
     }
 
-    const pagesCount = totalPagesCount;
-    final List<int> pages = [];
-    for (int currentPage = 1; currentPage <= pagesCount; currentPage++) {
-      final pageData = getPageData(currentPage);
-      for (int j = 0; j < pageData.length; j++) {
-        final currentSurahNum = pageData[j]['surah'];
-        if (currentSurahNum == surahNumber) {
-          pages.add(currentPage);
-          break;
-        }
-      }
-    }
-    return pages;
+    return List.unmodifiable(_surahToPages[surahNumber] ?? []);
   }
 
   ///Takes [surahNumber] & [verseNumber] and returns true if verse is sajdah


### PR DESCRIPTION

- Fix incorrect verse counting in getVerseCountByPage()
- Replace string throws with proper Dart exceptions (RangeError, ArgumentError)
- Add O(1) verse-to-page lookup map
- Add O(1) surah-to-pages lookup map
- Precompute reverse lookups during initialization
- Fix issue where Warsh pages appeared empty due to using Hafs page data for both narrations

resolve #50 

## Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.
