### PR TITLE
CI/CD: add support for building and publishing x86_64 Linux executables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,20 +157,98 @@ jobs:
               with:
                   name: apks
                   path: build/app/outputs/apk/release/*.apk
-                  
+
+    build_linux_x86_64:
+        name: Build Release Linux
+        needs: [get-version-info]
+        runs-on: ubuntu-22.04
+        env:
+          WORKING_DIR: build/linux/x64/release/bundle
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup Flutter
+              uses: subosito/flutter-action@v2
+              with:
+                  channel: "stable"
+                  flutter-version-file: pubspec.yaml
+                  cache: true
+            
+            - name: Install dependencies
+              run: |
+                flutter pub get
+                sudo apt update && sudo apt install -y \
+                clang \
+                cmake \
+                ninja-build \
+                libgtk-3-dev \
+                libfuse2 \
+                appstream
+
+            - name: Build Linux App
+              env:
+                APP_VERSION: ${{ needs.get-version-info.outputs.version }}
+                APP_BUILD: ${{ needs.get-version-info.outputs.build_number }}
+              run: |
+                flutter build linux --release \
+                  --dart-define=APP_VERSION="${{ env.APP_VERSION }}" \
+                  --dart-define=APP_BUILD="${{ env.APP_BUILD }}"
+            
+            - name: Get version from pubspec.yaml
+              id: get_version
+              run: |
+                VERSION=$(sed -n 's/^version: \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p' pubspec.yaml)
+                echo "VERSION=$VERSION" >> $GITHUB_ENV   
+
+            - name: Create portable version
+              run: |
+                cp assets/icon-cricle.png ${{ env.WORKING_DIR }}/my_quran.png
+                tar -cvzf MyQuran-${VERSION}-linux-x86_64.tar.gz -C ${{ env.WORKING_DIR }} .  
+            
+            - name: Prepare AppDir for packaging as an AppImage
+              run: |
+                mkdir -p AppDir/usr/share/icons/hicolor/512x512/apps
+                
+                cp -r ${{ env.WORKING_DIR }}/* AppDir/
+                cp linux/packaging/my_quran.desktop AppDir/
+                cp linux/packaging/appimage/AppRun AppDir/
+                cp ${{ env.WORKING_DIR }}/my_quran.png AppDir/usr/share/icons/hicolor/512x512/apps
+
+            - name: Install appimagetool (For packaging as an appimage)
+              run: |
+                curl -L -o appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+                chmod +x appimagetool
+            
+            - name: Build Appimage
+              run: ./appimagetool AppDir/ MyQuran-${VERSION}-linux-x86_64.AppImage
+              
+            - name: Upload Android Artifacts
+              uses: actions/upload-artifact@v7
+              with:
+                  name: linuxBuilds_x64_86
+                  path: |
+                    *linux-x86_64.tar.gz
+                    *linux-x86_64.AppImage
+                    
     release:
         name: Publish Release
-        needs: [build_android, get-version-info]
+        needs: [build_android, build_linux_x86_64, get-version-info]
         runs-on: ubuntu-latest
 
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
               
-            - name: Download All Artifacts
-              uses: actions/download-artifact@v7
+            - uses: actions/download-artifact@v7
               with:
                   name: apks
+                  path: artifacts
+            
+            - uses: actions/download-artifact@v7
+              with:
+                  name: linuxBuilds_x64_86
                   path: artifacts
 
             - name: Create GitHub Release
@@ -180,7 +258,10 @@ jobs:
                   prerelease: ${{ github.event.inputs.prerelease }}
                   draft: ${{ github.event.inputs.draft }}
                   bodyFile: fastlane/metadata/android/en-US/changelogs/${{ needs.get-version-info.outputs.build_number }}.txt
-                  artifacts: "artifacts/*.apk"
+                  artifacts: >
+                    artifacts/*.apk,
+                    artifacts/*.tar.gz,
+                    artifacts/*.AppImage
                   token: ${{ secrets.GITHUB_TOKEN }}
                  
     build_web_artifact:

--- a/linux/packaging/appimage/AppRun
+++ b/linux/packaging/appimage/AppRun
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+this_dir="$(readlink -f "$(dirname "$0")")"
+exec "$this_dir"/my_quran

--- a/linux/packaging/my_quran.desktop
+++ b/linux/packaging/my_quran.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=My Quran
+GenericName=Holy Quran
+GenericName[ar]=القرآن الكريم
+Comment=A lightweight, offline Quran with search
+Comment[ar]=تطبيق قرآن كريم خفيف، يعمل بدون إنترنت ويدعم البحث
+Exec=my_quran
+Icon=my_quran
+Type=Application
+Categories=Education;
+Keywords=Islam;Quran;Muslim;
+


### PR DESCRIPTION
The supported formats are:
- Appimage
- Tarball

Closes #57 
closes #27 