### PR TITLE
CD: Add support for building and publishing x86_64 Windows executables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,10 +231,74 @@ jobs:
                   path: |
                     *linux-x86_64.tar.gz
                     *linux-x86_64.AppImage
-                    
+
+    build_windows_x86_64:
+        name: Build Release windows
+        needs: [get-version-info]
+        runs-on: windows-2022
+        env:
+          WORKING_DIR: build/windows/x64/runner/Release/
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup Flutter
+              uses: subosito/flutter-action@v2
+              with:
+                  channel: "stable"
+                  flutter-version-file: pubspec.yaml
+                  cache: true
+            
+            - name: Install dependencies
+              run: flutter pub get
+
+            - name: Get version from pubspec.yaml
+              shell: pwsh
+              run: |
+                $versionLine = Select-String -Path pubspec.yaml -Pattern '^version:\s*([0-9]+\.[0-9]+\.[0-9]+)'
+                if ($versionLine -match '([0-9]+\.[0-9]+\.[0-9]+)') {
+                    $VERSION = $Matches[1]
+                    echo "VERSION=$VERSION" >> $env:GITHUB_ENV
+                } else {
+                    Write-Error "Version not found in pubspec.yaml"
+                }  
+
+            - name: Build Windows App
+              env:
+                APP_VERSION: ${{ needs.get-version-info.outputs.version }}
+                APP_BUILD: ${{ needs.get-version-info.outputs.build_number }}
+              run: |
+                flutter build windows --release `
+                  --dart-define=APP_VERSION="${{ env.APP_VERSION }}" `
+                  --dart-define=APP_BUILD="${{ env.APP_BUILD }}"
+            
+            # See https://docs.flutter.dev/platform-integration/windows/building#building-your-own-zip-file-for-windows      
+            - name: Add runtime files
+              run: |
+                Copy-Item "C:\Windows\System32\msvcp140.dll" "${{env.WORKING_DIR}}"
+                Copy-Item "C:\Windows\System32\vcruntime140.dll" "${{env.WORKING_DIR}}"
+                Copy-Item "C:\Windows\System32\vcruntime140_1.dll" "${{env.WORKING_DIR}}"
+            
+            - name: Add app icon
+              run: Copy-Item assets/icon-cricle.png ${{env.WORKING_DIR}}/my_quran.png
+
+            - name: Create portable version
+              run: Compress-Archive -Path "${{env.WORKING_DIR}}*" -DestinationPath "MyQuran-$env:VERSION-windows-x86_64.zip"
+            
+            - name: Create app installer (setup)
+              run: iscc /DMyAppVersion=$env:VERSION windows/packaging/inno-setup.iss
+              
+            - name: Upload Windows Artifacts
+              uses: actions/upload-artifact@v7
+              with:
+                  name: windowsBuilds_x64_86
+                  path: |
+                    *windows-x86_64.zip
+                    *windows-x86_64-setup.exe  
     release:
         name: Publish Release
-        needs: [build_android, build_linux_x86_64, get-version-info]
+        needs: [build_android, build_linux_x86_64, build_windows_x86_64, get-version-info]
         runs-on: ubuntu-latest
 
         steps:
@@ -251,6 +315,11 @@ jobs:
                   name: linuxBuilds_x64_86
                   path: artifacts
 
+            - uses: actions/download-artifact@v7
+              with:
+                  name: windowsBuilds_x64_86
+                  path: artifacts      
+
             - name: Create GitHub Release
               uses: ncipollo/release-action@v1
               with:
@@ -261,7 +330,9 @@ jobs:
                   artifacts: >
                     artifacts/*.apk,
                     artifacts/*.tar.gz,
-                    artifacts/*.AppImage
+                    artifacts/*.AppImage,
+                    artifacts/*.zip,
+                    artifacts/*.exe
                   token: ${{ secrets.GITHUB_TOKEN }}
                  
     build_web_artifact:

--- a/windows/packaging/inno-setup.iss
+++ b/windows/packaging/inno-setup.iss
@@ -1,0 +1,68 @@
+#define MyAppName "My Quran"
+#ifndef MyAppVersion
+  #define MyAppVersion "1.0.0"
+#endif
+#define MyAppPublisher "DMouayad"
+#define MyAppURL "https://github.com/DMouayad/my_quran"
+#define MyAppExeName "my_quran.exe"
+#define WorkingDir "D:\a\my_quran\my_quran"
+
+; --- Detect platform at compile time ---
+#define Arch1 GetEnv("PROCESSOR_ARCHITECTURE")
+#define Arch2 GetEnv("PROCESSOR_ARCHITEW6432")
+
+#if (Pos("ARM64", UpperCase(Arch1)) > 0) || (Pos("ARM64", UpperCase(Arch2)) > 0)
+  #define BuildArch "arm64"
+#else
+  #define BuildArch "x64"
+#endif
+
+#define OutputArch StringChange(BuildArch, "x64", "x86_64")
+
+[Setup]
+AppId={{f4353203-40d1-4220-b710-b2b672191181}}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+UninstallDisplayName={#MyAppName}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={autopf}\{#MyAppName}
+DisableProgramGroupPage=yes
+; Uncomment the following line to run in non administrative install mode (install for current user only.)
+;PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+OutputDir={#WorkingDir}
+OutputBaseFilename=MyQuran-{#MyAppVersion}-windows-{#OutputArch}-setup
+SetupIconFile={#WorkingDir}\windows\runner\resources\app_icon.ico
+UninstallDisplayIcon={app}\{#MyAppExeName}
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+; SignTool=MySignTool (Used to sign the app)
+ArchitecturesInstallIn64BitMode=x64compatible
+ArchitecturesAllowed=x64compatible
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+; Optional task that creates a desktop shortcut if the user checks it during installation.
+; Note: Flags: checkedonce means it's checked by default (on fresh installs).
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: checkedonce
+
+; Optional task that creates a Start Menu shortcut.
+Name: "startmenuicon"; Description: "Create a Start Menu shortcut"; GroupDescription: "{cm:AdditionalIcons}"; Flags: checkedonce
+
+[Files]
+Source: "{#WorkingDir}\build\windows\{#BuildArch}\runner\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#WorkingDir}\build\windows\{#BuildArch}\runner\Release\*.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#WorkingDir}\build\windows\{#BuildArch}\runner\Release\data\*"; DestDir: "{app}\data"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: startmenuicon
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
The supported formats are:

- Installer (Setup.exe)
- Portable version

Closes #59 

Preview:

<img width="445" height="321" alt="Screenshot 2026-03-05_09-21" src="https://github.com/user-attachments/assets/83292d11-e26c-437e-9d54-e1813aa8cd6c" />

<img width="802" height="619" alt="Screenshot 2026-03-05_09-22" src="https://github.com/user-attachments/assets/f3f4f811-f15b-45fa-bef6-c4ff1dd91d98" />

<img width="803" height="619" alt="Screenshot 2026-03-05_09-22_1" src="https://github.com/user-attachments/assets/4acf4ca3-bd8b-40d1-b1d6-b52f4d6512dd" />

<img width="1920" height="746" alt="Screenshot 2026-03-05_09-26" src="https://github.com/user-attachments/assets/476562a9-7a1e-47bd-a864-0e7562ce8d2f" />


<img width="1920" height="1036" alt="Screenshot 2026-03-04_13-24" src="https://github.com/user-attachments/assets/e6e56b89-b4dc-4d49-95f4-af9adc296190" />

