### PR TITLE
feat: auto-bookmark under sole tag when only one exists

### DIFF
--- a/lib/app/widgets/verse_menu_dialog.dart
+++ b/lib/app/widgets/verse_menu_dialog.dart
@@ -321,7 +321,6 @@ class _VerseMenuDialogState extends State<VerseMenuDialog> {
     }
 
     final result = await showModalBottomSheet<BookmarkPickerResult>(
-
       context: context,
       useRootNavigator: true,
       isScrollControlled: true,

--- a/lib/app/widgets/verse_menu_dialog.dart
+++ b/lib/app/widgets/verse_menu_dialog.dart
@@ -313,7 +313,15 @@ class _VerseMenuDialogState extends State<VerseMenuDialog> {
   }
 
   Future<void> _openBookmarkPicker(BuildContext context) async {
+    // If the user has exactly one tag and this verse isn't bookmarked yet,
+    // save it under that sole tag directly instead of showing the picker.
+    if (!isBookmarked && categories.length == 1) {
+      await _onCategorySelected(context, categories.first);
+      return;
+    }
+
     final result = await showModalBottomSheet<BookmarkPickerResult>(
+
       context: context,
       useRootNavigator: true,
       isScrollControlled: true,


### PR DESCRIPTION
## What

When bookmarking a verse and the user has exactly one tag, the category picker is skipped and the bookmark is saved directly under that sole tag. Users with more than one tag keep the normal picker behavior.

- Guard in `verse_menu_dialog.dart` → `_openBookmarkPicker`: if `!isBookmarked && categories.length == 1`, call `_onCategorySelected(context, categories.first)` and return (no sheet).
- Edit / remove / multi-tag flows unchanged — they still open the picker.
- Safe because the app ships with default tags (min tags = 1); a 0-tag state isn't reachable from this UI.

## Files

- `lib/app/widgets/verse_menu_dialog.dart` — sole change (7 lines)