### PR TITLE
fix(backup): export not working on linux and web

### DIFF
--- a/lib/app/services/backup_service.dart
+++ b/lib/app/services/backup_service.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
-import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/foundation.dart';
+import 'package:my_quran/app/utils.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
@@ -60,39 +61,50 @@ class BackupService {
       appBuild: appBuild,
     );
 
-    final dir = await getTemporaryDirectory();
+    final String? dir = isMobile
+        ? (await getTemporaryDirectory()).path
+        : isDesktop
+        ? await getDirectoryPath()
+        : null;
+    if (isDesktop && !kIsWeb && dir == null) return;
 
     final safeVersion = appVersion.isEmpty ? 'unknown' : appVersion;
     final safeBuild = (appBuild == null) ? '0' : appBuild.toString();
 
     final fileName =
         'my_quran-backup-v$schemaVersion-$safeVersion+$safeBuild-'
-        '${DateTime.now().toIso8601String().replaceAll(':', '-')}.json.gz';
+        '${DateTime.now().toIso8601String().replaceAll(':', '-')}.json';
 
-    final file = File('${dir.path}/$fileName');
-    await file.writeAsBytes(bytes, flush: true);
+    final file = XFile.fromData(
+      bytes,
+      name: fileName,
+      path: dir != null ? '$dir/$fileName' : null,
+      mimeType: 'application/json',
+    );
+    /// if [path] is null then [file.path] 
+    /// will be a Blob URL on web-browsers.
+    await file.saveTo(file.path);
 
-    await SharePlus.instance.share(
-      ShareParams(
-        files: [XFile(file.path, mimeType: 'application/gzip')],
-        subject: 'My Quran Backup',
-        text: 'Backup file (bookmarks + notes).',
-      ),
+    if (isMobile) {
+      await SharePlus.instance.share(
+        ShareParams(
+          files: [file],
+          subject: 'My Quran Backup',
+          text: 'Backup file (bookmarks + notes).',
+        ),
+      );
+    }
+  }
+
+  Future<XFile?> pickBackupFile() async {
+    return openFile(
+      acceptedTypeGroups: [
+        const XTypeGroup(extensions: ['json']),
+      ],
     );
   }
 
-  Future<File?> pickBackupFile() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['gz', 'json'],
-    );
-    if (result == null || result.files.isEmpty) return null;
-    final path = result.files.single.path;
-    if (path == null) return null;
-    return File(path);
-  }
-
-  Future<BackupPreview> preview(File file) async {
+  Future<BackupPreview> preview(XFile file) async {
     final doc = await _readBackupDoc(file);
     final data = doc['data'] as Map<String, dynamic>? ?? const {};
 
@@ -118,7 +130,7 @@ class BackupService {
     );
   }
 
-  Future<void> import(File file, {required ImportMode mode}) async {
+  Future<void> import(XFile file, {required ImportMode mode}) async {
     final doc = await _readBackupDoc(file);
 
     final ver = doc['schemaVersion'] as int? ?? 0;
@@ -182,7 +194,7 @@ class BackupService {
 
   // ---------- Export implementation ----------
 
-  Future<List<int>> _exportBytes({
+  Future<Uint8List> _exportBytes({
     required String appVersion,
     required int? appBuild,
   }) async {
@@ -206,17 +218,15 @@ class BackupService {
       },
     };
 
-    final raw = utf8.encode(jsonEncode(doc));
-    return gzip.encode(raw);
+    return utf8.encode(jsonEncode(doc));
   }
 
   // ---------- Import implementation (read/validate) ----------
 
-  Future<Map<String, dynamic>> _readBackupDoc(File file) async {
+  Future<Map<String, dynamic>> _readBackupDoc(XFile file) async {
     final bytes = await file.readAsBytes();
-    final decoded = _decodeMaybeGzip(bytes);
 
-    final obj = jsonDecode(utf8.decode(decoded));
+    final obj = jsonDecode(utf8.decode(bytes));
     if (obj is! Map<String, dynamic>) {
       throw const FormatException('Backup root is not a JSON object');
     }
@@ -226,11 +236,6 @@ class BackupService {
     }
 
     return obj;
-  }
-
-  List<int> _decodeMaybeGzip(List<int> bytes) {
-    final isGz = bytes.length >= 2 && bytes[0] == 0x1F && bytes[1] == 0x8B;
-    return isGz ? gzip.decode(bytes) : bytes;
   }
 
   // ---------- Apply strategies ----------

--- a/lib/app/services/backup_service.dart
+++ b/lib/app/services/backup_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:archive/archive.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
 import 'package:my_quran/app/utils.dart';
@@ -61,13 +62,6 @@ class BackupService {
       appBuild: appBuild,
     );
 
-    final String? dir = isMobile
-        ? (await getTemporaryDirectory()).path
-        : isDesktop
-        ? await getDirectoryPath()
-        : null;
-    if (isDesktop && !kIsWeb && dir == null) return;
-
     final safeVersion = appVersion.isEmpty ? 'unknown' : appVersion;
     final safeBuild = (appBuild == null) ? '0' : appBuild.toString();
 
@@ -75,17 +69,28 @@ class BackupService {
         'my_quran-backup-v$schemaVersion-$safeVersion+$safeBuild-'
         '${DateTime.now().toIso8601String().replaceAll(':', '-')}.json';
 
-    final file = XFile.fromData(
-      bytes,
-      name: fileName,
-      path: dir != null ? '$dir/$fileName' : null,
-      mimeType: 'application/json',
-    );
-    /// if [path] is null then [file.path] 
-    /// will be a Blob URL on web-browsers.
-    await file.saveTo(file.path);
+    // Web: trigger browser download
+    if (kIsWeb) {
+      final file = XFile.fromData(
+        bytes,
+        name: fileName,
+        mimeType: 'application/json',
+      );
+      // On web saveTo with empty path triggers download of `name`
+      await file.saveTo(fileName);
+      return;
+    }
 
-    if (isMobile) {
+    if (isMobilePlatform) {
+      final dir = await getTemporaryDirectory();
+      final path = '${dir.path}/$fileName';
+      final file = XFile.fromData(
+        bytes,
+        name: fileName,
+        path: path,
+        mimeType: 'application/json',
+      );
+      await file.saveTo(path);
       await SharePlus.instance.share(
         ShareParams(
           files: [file],
@@ -93,13 +98,27 @@ class BackupService {
           text: 'Backup file (bookmarks + notes).',
         ),
       );
+      return;
     }
+
+    // Desktop (Windows/Linux/macOS)
+    final dir = await getDirectoryPath();
+    if (dir == null) return; // user cancelled
+    final path = '$dir/$fileName';
+    final file = XFile.fromData(
+      bytes,
+      name: fileName,
+      path: path,
+      mimeType: 'application/json',
+    );
+    await file.saveTo(path);
   }
 
   Future<XFile?> pickBackupFile() async {
     return openFile(
       acceptedTypeGroups: [
-        const XTypeGroup(extensions: ['json']),
+        const XTypeGroup(label: 'JSON', extensions: ['json']),
+        const XTypeGroup(label: 'GZip JSON', extensions: ['gz', 'json.gz']),
       ],
     );
   }
@@ -225,8 +244,9 @@ class BackupService {
 
   Future<Map<String, dynamic>> _readBackupDoc(XFile file) async {
     final bytes = await file.readAsBytes();
+    final decoded = _decodeMaybeGzip(bytes);
 
-    final obj = jsonDecode(utf8.decode(bytes));
+    final obj = jsonDecode(utf8.decode(decoded));
     if (obj is! Map<String, dynamic>) {
       throw const FormatException('Backup root is not a JSON object');
     }
@@ -236,6 +256,18 @@ class BackupService {
     }
 
     return obj;
+  }
+
+  List<int> _decodeMaybeGzip(List<int> bytes) {
+    final isGz = bytes.length >= 2 && bytes[0] == 0x1F && bytes[1] == 0x8B;
+    if (!isGz) return bytes;
+    try {
+      return const GZipDecoder().decodeBytes(bytes);
+    } on ArchiveException {
+      // If gzip header present but decode fails, fall back to raw bytes
+      // so jsonDecode can throw a clearer FormatException.
+      return bytes;
+    }
   }
 
   // ---------- Apply strategies ----------

--- a/lib/app/utils.dart
+++ b/lib/app/utils.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:my_quran/app/models.dart';
 
-bool get isDesktop {
+bool get isDesktopPlatform {
   return switch (defaultTargetPlatform) {
     TargetPlatform.windows ||
     TargetPlatform.macOS ||
@@ -11,7 +11,7 @@ bool get isDesktop {
   };
 }
 
-bool get isMobile {
+bool get isMobilePlatform {
   return switch (defaultTargetPlatform) {
     TargetPlatform.android || TargetPlatform.iOS => true,
     _ => false,

--- a/lib/app/utils.dart
+++ b/lib/app/utils.dart
@@ -1,5 +1,22 @@
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:my_quran/app/models.dart';
+
+bool get isDesktop {
+  return switch (defaultTargetPlatform) {
+    TargetPlatform.windows ||
+    TargetPlatform.macOS ||
+    TargetPlatform.linux => true,
+    _ => false,
+  };
+}
+
+bool get isMobile {
+  return switch (defaultTargetPlatform) {
+    TargetPlatform.android || TargetPlatform.iOS => true,
+    _ => false,
+  };
+}
 
 String getArabicNumber(int number) {
   const arabicNumerals = ['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩'];

--- a/lib/app/widgets/settings_sheet.dart
+++ b/lib/app/widgets/settings_sheet.dart
@@ -311,7 +311,9 @@ class SettingsSheet extends StatelessWidget {
                     _ActionRow(
                       icon: Icons.upload_file,
                       title: 'تصدير نسخة احتياطية',
-                      subtitle: 'مشاركة ملف النسخة أو حفظه',
+                      subtitle:
+                          'مشاركة الملف — سيتم تنزيله تلقائياً إذا '
+                          'كانت المشاركة غير مدعومة',
                       onTap: () async {
                         await BackupService().exportAndShare();
                       },

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <dynamic_color/dynamic_color_plugin.h>
+#include <file_selector_linux/file_selector_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
   dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
+  file_selector_linux
   url_launcher_linux
 )
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,14 +137,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  file_picker:
+  file_selector:
     dependency: "direct main"
     description:
-      name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      name: file_selector
+      sha256: bd15e43e9268db636b53eeaca9f56324d1622af30e5c34d6e267649758c84d9a
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "1.1.0"
+  file_selector_android:
+    dependency: transitive
+    description:
+      name: file_selector_android
+      sha256: "1d45e9910f68c16eb0c74f0b10097ad81aed516ea28054c027137e8f7d75e840"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2+9"
+  file_selector_ios:
+    dependency: transitive
+    description:
+      name: file_selector_ios
+      sha256: e2ecf2885c121691ce13b60db3508f53c01f869fb6e8dc5c1cfa771e4c46aeca
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.3+5"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_web:
+    dependency: transitive
+    description:
+      name: file_selector_web
+      sha256: "73181fbc5257776d8ecaa6a94ab3c8e920ad143b9132a6d984a9271dfc6928d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:
@@ -171,14 +227,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_plugin_android_lifecycle:
-    dependency: transitive
-    description:
-      name: flutter_plugin_android_lifecycle
-      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.34"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2,13 +2,13 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
-      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      sha256: ace891da0862b0e4cabbb064ee3fd87b2728b898949fdb366d83fe98342c9f19
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.9"
+    version: "4.2.0"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
     collection: ^1.19.1
     dynamic_color: ^1.8.1
-    file_picker: ^10.3.10
+    file_selector: ^1.1.0
     flutter:
         sdk: flutter
     flutter_localizations:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
     flutter: 3.44.6
 
 dependencies:
+    archive: ^4.2.0
     collection: ^1.19.1
     dynamic_color: ^1.8.1
     file_selector: ^1.1.0

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,15 @@
 #include "generated_plugin_registrant.h"
 
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   DynamicColorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
+  file_selector_windows
   share_plus
   url_launcher_windows
 )


### PR DESCRIPTION
There are two issues in the current code:

- The `share_plus` package is not supported on Linux.
- The import of `dart:io` inside `backup_service.dart` file makes the app crash on the web platform when backup button is clicked because `dart:io` is not supported on web.

### The `share_plus` package is not supported on Linux:
For fixing this issue, I use the `share_plus` package only on mobile (Android and iOS). So the behavior becomes:
- On Android and iOS => uses native share via `share_plus`.
- On Windows, Linux, macOS => the user picks a folder to save, and it writes the exported backup to it.
- On web => it starts downloading the exported backup via web browser.

### The `dart:io` issue on web:
This is the reason why I replaced the `file_picker` package with `file_selector`. The `file_selector` package supports the `saveTo()` API, which eliminates the need to use the `File().write` API from `dart:io`, making the current implementation work on mobile, desktop, and web without issues.

By removing any code that uses `dart:io` from `backup_service.dart`, this leads to losing the step of compressing backups via `gzip`, which lives inside `dart:io`. I was not sure if I should add a replacement for it that works on web (e.g., `archive` package) because a new replacement means a new dependency added to `pubspec.yaml`. So I kept it lightweight without adding extra deps since the data that will be compressed is small.